### PR TITLE
amended with plus minus and lambda

### DIFF
--- a/ToPython.wl
+++ b/ToPython.wl
@@ -21,9 +21,13 @@ BeginPackage["ToPython`"]
 ToPython::usage = "ToPython[expression, NumpyPrefix->\"np\", Copy->False]
     converts Mathematica expression to a Numpy compatible expression. Because Numpy can
     be imported in several ways, you can specify the name of the numpy module using the
+    converts Mathematica expression to a Numpy compatible expression. Because Numpy can
+    be imported in several ways, you can specify the name of the numpy module using the
     NumpyPrefix option. The additional option Copy allows you to copy the result to the clipboard"
 
+
 ToPythonEquation::usage = "ToPythonEquation[equation, NumpyPrefix->\"np\", Copy->False]
+    converts a Mathematica equation to a Numpy compatible expression."
     converts a Mathematica equation to a Numpy compatible expression."
 
 Begin["Private`"]
@@ -139,7 +143,7 @@ ToPython[expression_, OptionsPattern[]] :=
              -> "gamma", "\[Delta]" -> "delta", "\[Epsilon]" -> "epsilon", "\[CurlyEpsilon]"
              -> "curlyepsilon", "\[Zeta]" -> "zeta", "\[Eta]" -> "eta", "\[Theta]"
              -> "theta", "\[Iota]" -> "iota", "\[Kappa]" -> "kappa", "\[Lambda]" 
-            -> "lambda", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
+            -> "lamb", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
              -> "omicron", "\[Pi]" -> "pi", "\[Rho]" -> "rho", "\[FinalSigma]" ->
              "finalsigma", "\[Sigma]" -> "sigma", "\[Tau]" -> "tau", "\[Upsilon]"
              -> "upsilon", "\[CurlyPhi]" -> "curlyphi", "\[Chi]" -> "chi", "\[Phi]"
@@ -154,12 +158,14 @@ ToPython[expression_, OptionsPattern[]] :=
              -> "Tau", "\[CapitalUpsilon]" -> "Upsilon", "\[CapitalPhi]" -> "CurlyPhi",
              "\[CapitalChi]" -> "Chi", "\[CapitalPsi]" -> "Psi", "\[CapitalOmega]"
              -> "Omega"};
+        plusminusrule = {"+ -" -> "-"};
         (* Everything else *)
         PythonForm[h_[args__]] := np <> ToLowerCase[PythonForm[h]] <>
              "(" <> PythonForm[args] <> ")";
         PythonForm[allOther_] := StringReplace[ToString[allOther, FortranForm
             ], greekrule];
-        result = StringReplace[PythonForm[expression], greekrule];
+        result = StringReplace[PythonForm[expression], greekrule ~ Join
+             ~ plusminusrule];
         (* Copy results to clipboard *)
         If[copy,
             CopyToClipboard[result]
@@ -168,10 +174,14 @@ ToPython[expression_, OptionsPattern[]] :=
     ]
 
 Options[ToPythonEquation] = {NumpyPrefix -> "np", Copy -> False};
+Options[ToPythonEquation] = {NumpyPrefix -> "np", Copy -> False};
 
+ToPythonEquation[Equal[a_, b_], opts : OptionsPattern[]] :=
+    ToPython[a - b, opts]
 ToPythonEquation[Equal[a_, b_], opts : OptionsPattern[]] :=
     ToPython[a - b, opts]
 
 End[]
+
 
 EndPackage[]

--- a/ToPython.wl
+++ b/ToPython.wl
@@ -21,13 +21,9 @@ BeginPackage["ToPython`"]
 ToPython::usage = "ToPython[expression, NumpyPrefix->\"np\", Copy->False]
     converts Mathematica expression to a Numpy compatible expression. Because Numpy can
     be imported in several ways, you can specify the name of the numpy module using the
-    converts Mathematica expression to a Numpy compatible expression. Because Numpy can
-    be imported in several ways, you can specify the name of the numpy module using the
     NumpyPrefix option. The additional option Copy allows you to copy the result to the clipboard"
 
-
 ToPythonEquation::usage = "ToPythonEquation[equation, NumpyPrefix->\"np\", Copy->False]
-    converts a Mathematica equation to a Numpy compatible expression."
     converts a Mathematica equation to a Numpy compatible expression."
 
 Begin["Private`"]
@@ -174,14 +170,10 @@ ToPython[expression_, OptionsPattern[]] :=
     ]
 
 Options[ToPythonEquation] = {NumpyPrefix -> "np", Copy -> False};
-Options[ToPythonEquation] = {NumpyPrefix -> "np", Copy -> False};
 
-ToPythonEquation[Equal[a_, b_], opts : OptionsPattern[]] :=
-    ToPython[a - b, opts]
 ToPythonEquation[Equal[a_, b_], opts : OptionsPattern[]] :=
     ToPython[a - b, opts]
 
 End[]
-
 
 EndPackage[]


### PR DESCRIPTION
Two minor changes:
- added rule that replaces instances of "+ -" to "-". Not a major deal this was happening but easier for linter to understand where to break the lines like that, and,
-  changed "lambda" replacement target to "lamb" as "lambda" has special meaning in python. Potentially `\[Pi]` is also dangerous (i.e. maybe best keep it out of the replacement list) butI didn't want to make a design choice