### PR TITLE
linted using wl's linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ To install the package permanently, do the following
 
 You should be ready to go.
 
-
 ## Usage
 
 The package mainly provides the `ToPython` function, which takes a Mathematica expression
@@ -31,17 +30,18 @@ already, but it is obviously limited.
 Beside the actual expression the `ToPython` function also supports two options:
 
 * `NumpyPrefix`, which determines the name under which numpy is imported. The default is
-  to prefix all numpy call with `np.`, but you can also set `NumpyPrefix` to `"numpy"` to 
-  enforce `numpy.` as a prefix. If you supply an empty string, no prefix is added, which 
+  to prefix all numpy call with `np.`, but you can also set `NumpyPrefix` to `"numpy"` to
+  enforce `numpy.` as a prefix. If you supply an empty string, no prefix is added, which
   might be useful if you use the wildcard import `from numpy import *`
 * `Copy`, which when enabled copies the formatted expression to the clipboard
 
 Taken together, a simple example call is
+
 ```Mathematica
 ToPython[Sin[x], NumpyPrefix->"numpy", Copy->True]
 ```
-which should copy `numpy.sin(x)` to your clipboard.
 
+which should copy `numpy.sin(x)` to your clipboard.
 
 ## Disclaimer
 

--- a/ToPython.wl
+++ b/ToPython.wl
@@ -16,140 +16,162 @@ Not tested for every possible combination; use at your risk, by Gustavo Wiederhe
 modifications by David Zwicker
 *)
 
-
 BeginPackage["ToPython`"]
 
 ToPython::usage = "ToPython[expression, NumpyPrefix->\"np\", Copy->False]
-	converts Mathematica expression to a Numpy compatible expression. Because Numpy can
-	be imported in several ways, you can specify the name of the numpy module using the
+    converts Mathematica expression to a Numpy compatible expression. Because Numpy can
+    be imported in several ways, you can specify the name of the numpy module using the
     NumpyPrefix option. The additional option Copy allows you to copy the result to the clipboard"
- 
-ToPythonEquation::usage = "ToPythonEquation[equation, NumpyPrefix->\"np\", Copy->False]
-	converts a Mathematica equation to a Numpy compatible expression."
- 
 
+ToPythonEquation::usage = "ToPythonEquation[equation, NumpyPrefix->\"np\", Copy->False]
+    converts a Mathematica equation to a Numpy compatible expression."
 
 Begin["Private`"]
 
-
 (* list of function heads that do not need to be enclosed in brackets *)
-singleFunctions={Log, Sin, Cos, Tan, Sinh, Cosh, Tanh};
 
+singleFunctions = {Log, Sin, Cos, Tan, Sinh, Cosh, Tanh};
 
-Options[ToPython] = {NumpyPrefix->"np", Copy->False};
-ToPython[expression_, OptionsPattern[]] := Module[
-	{numpyprefix=OptionValue[NumpyPrefix], copy=OptionValue[Copy],
-	result, greekrule, format, PythonForm, np, br, brackets, a, b, l, m, args},
+Options[ToPython] = {NumpyPrefix -> "np", Copy -> False};
 
-(* determine the correct numpy prefix *)
-If[numpyprefix=="", np=numpyprefix, np=numpyprefix<>"."];
+ToPython[expression_, OptionsPattern[]] :=
+    Module[
+        {numpyprefix = OptionValue[NumpyPrefix], copy = OptionValue[Copy
+            ], result, greekrule, format, PythonForm, np, br, brackets, a, b, l, 
+            m, args}
+        ,
+        (* determine the correct numpy prefix *)
+        If[numpyprefix == "",
+            np = numpyprefix
+            ,
+            np = numpyprefix <> "."
+        ];
+        (* general function for formating output *)
+        format[pattern_String, args__] :=
+            Module[{s},
+                s = StringReplace[pattern, "numpy." -> np];
+                ToString @ StringForm[s, Sequence @@ PythonForm /@ List[
+                    args]]
+            ];
+        (* helper function deciding when to use brackets *)
+        br[a_] :=
+            If[AtomQ[a] || MemberQ[singleFunctions, Head[a]],
+                a
+                ,
+                brackets[a]
+            ];
+        PythonForm[brackets[a_]] := format["(``)", a];
+        (* special forms that are recognized *)
+        PythonForm[Times[-1, a_]] := format["-``", br[a]];
+        PythonForm[Power[a_, Rational[1, 2]]] := format["numpy.sqrt(``)",
+             a];
+        PythonForm[Times[a_, Power[b_, -1]]] := format["`` / ``", br[
+            a], br[b]];
+        (* special forms that are not supported *)
+        ToPython::hasDerivative = "Dervatives are not supported";
+        PythonForm[Derivative[___]] :=
+            (
+                Message[ToPython::hasDerivative];
+                Abort[]
+            );
+        (* Simple math *)
+        PythonForm[Rational[a_, b_]] := ToString[N[a / b, $MachinePrecision
+            ], FortranForm];
+        PythonForm[a_Rational] := ToString[N[a, $MachinePrecision], FortranForm
+            ];
+        PythonForm[Complex[a_, b_]] := format["complex(``, ``)", a, b
+            ];
+        PythonForm[a_ * b__] :=
+            Module[{fs, bl = {b}},
+                fs = StringRiffle[ConstantArray["``", 1 + Length @ bl
+                    ], " * "];
+                format[fs, br @ a, Sequence @@ br /@ bl]
+            ];
+        PythonForm[a_ + b_] := format["`` + ``", a, b];
+        PythonForm[Power[a_, b_]] := format["`` ** ``", br[a], br[b]]
+            ;
+        PythonForm[Exp[a_]] := format["numpy.exp(``)", a];
+        (* Some basic functions *)
+        PythonForm[Max[a_, b_]] := format["numpy.maximum(`1`, `2`)", 
+            a, b];
+        PythonForm[Min[a_, b_]] := format["numpy.minimum(`1`, `2`)", 
+            a, b];
+        (* Some special functions *)
+        PythonForm[Arg[a_]] := format["numpy.angle(``)", a];
+        PythonForm[SphericalHarmonicY[l_, m_, a_, b_]] := format["special.sph_harm(``, ``, (``) % (2 * numpy.pi), (``) % numpy.pi)",
+             m, l, b, a];
+        PythonForm[Gamma[a_]] := format["special.gamma(``)", a];
+        PythonForm[Gamma[a_, b_]] := format["special.gamma(`1`) * special.gammaincc(`1`, `2`)",
+             a, b];
+        PythonForm[BesselI[0, b_]] := format["special.i0(``)", b];
+        PythonForm[BesselJ[0, b_]] := format["special.j0(``)", b];
+        PythonForm[BesselK[0, b_]] := format["special.k0(``)", b];
+        PythonForm[BesselY[0, b_]] := format["special.y0(``)", b];
+        PythonForm[BesselI[1, b_]] := format["special.i1(``)", b];
+        PythonForm[BesselJ[1, b_]] := format["special.j1(``)", b];
+        PythonForm[BesselK[1, b_]] := format["special.k1(``)", b];
+        PythonForm[BesselY[1, b_]] := format["special.y1(``)", b];
+        PythonForm[BesselI[a_, b_]] := format["special.iv(``, ``)", a,
+             b];
+        PythonForm[BesselJ[a_, b_]] := format["special.jv(``, ``)", a,
+             b];
+        PythonForm[BesselK[a_, b_]] := format["special.kn(``, ``)", a,
+             b];
+        PythonForm[BesselY[a_, b_]] := format["special.yn(``, ``)", a,
+             b];
+        (* Some functions that are not defined in numpy *)
+        PythonForm[Csc[a_]] := format["1 / numpy.sin(``)", a];
+        PythonForm[Sec[a_]] := format["1 / numpy.cos(``)", a];
+        PythonForm[Cot[a_]] := format["1 / numpy.tan(``)", a];
+        PythonForm[Csch[a_]] := format["1 / numpy.sinh(``)", a];
+        PythonForm[Sech[a_]] := format["1 / numpy.cosh(``)", a];
+        PythonForm[Coth[a_]] := format["1 / numpy.tanh(``)", a];
+        (* Handling arrays *)
+        PythonForm[a_NumericArray] := np <> "array(" <> StringReplace[
+            ToString @ Normal @ a, {"{" -> "[", "}" -> "]"}] <> ")";
+        PythonForm[List[args__]] := np <> "array([" <> StringRiffle[PythonForm
+             /@ List[args], ", "] <> "])";
+        (* Constants *)
+        PythonForm[\[Pi]] = np <> "pi";
+        PythonForm[E] = np <> "e";
+        (* Greek characters *)
+        greekrule = {"\[Alpha]" -> "alpha", "\[Beta]" -> "beta", "\[Gamma]"
+             -> "gamma", "\[Delta]" -> "delta", "\[Epsilon]" -> "epsilon", "\[CurlyEpsilon]"
+             -> "curlyepsilon", "\[Zeta]" -> "zeta", "\[Eta]" -> "eta", "\[Theta]"
+             -> "theta", "\[Iota]" -> "iota", "\[Kappa]" -> "kappa", "\[Lambda]" 
+            -> "lambda", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
+             -> "omicron", "\[Pi]" -> "pi", "\[Rho]" -> "rho", "\[FinalSigma]" ->
+             "finalsigma", "\[Sigma]" -> "sigma", "\[Tau]" -> "tau", "\[Upsilon]"
+             -> "upsilon", "\[CurlyPhi]" -> "curlyphi", "\[Chi]" -> "chi", "\[Phi]"
+             -> "phi", "\[Psi]" -> "psi", "\[Omega]" -> "omega", "\[CapitalAlpha]"
+             -> "Alpha", "\[CapitalBeta]" -> "Beta", "\[CapitalGamma]" -> "Gamma",
+             "\[CapitalDelta]" -> "Delta", "\[CapitalEpsilon]" -> "CurlyEpsilon",
+             "\[CapitalZeta]" -> "Zeta", "\[CapitalEta]" -> "Eta", "\[CapitalTheta]"
+             -> "Theta", "\[CapitalIota]" -> "Iota", "\[CapitalKappa]" -> "Kappa",
+             "\[CapitalLambda]" -> "Lambda", "\[CapitalMu]" -> "Mu", "\[CapitalNu]"
+             -> "Nu", "\[CapitalXi]" -> "Xi", "\[CapitalOmicron]" -> "Omicron", "\[CapitalPi]"
+             -> "Pi", "\[CapitalRho]" -> "Rho", "\[CapitalSigma]" -> "Sigma", "\[CapitalTau]"
+             -> "Tau", "\[CapitalUpsilon]" -> "Upsilon", "\[CapitalPhi]" -> "CurlyPhi",
+             "\[CapitalChi]" -> "Chi", "\[CapitalPsi]" -> "Psi", "\[CapitalOmega]"
+             -> "Omega"};
+        (* Everything else *)
+        PythonForm[h_[args__]] := np <> ToLowerCase[PythonForm[h]] <>
+             "(" <> PythonForm[args] <> ")";
+        PythonForm[allOther_] := StringReplace[ToString[allOther, FortranForm
+            ], greekrule];
+        result = StringReplace[PythonForm[expression], greekrule];
+        (* Copy results to clipboard *)
+        If[copy,
+            CopyToClipboard[result]
+        ];
+        result
+    ]
 
-(* general function for formating output *)
-format[pattern_String, args__] := Module[{s},
-	s = StringReplace[pattern, "numpy."->np];
-	ToString @ StringForm[s, Sequence @@ PythonForm /@ List[args]]
-];
+Options[ToPythonEquation] = {NumpyPrefix -> "np", Copy -> False};
 
-(* helper function deciding when to use brackets *)
-br[a_] := If[AtomQ[a] || MemberQ[singleFunctions, Head[a]], a, brackets[a]];
-PythonForm[brackets[a_]] := format["(``)", a];
-
-(* special forms that are recognized *)
-PythonForm[Times[-1, a_]] := format["-``", br[a]];
-PythonForm[Power[a_, Rational[1, 2]]] := format["numpy.sqrt(``)", a];
-PythonForm[Times[a_, Power[b_, -1]]] := format["`` / ``", br[a], br[b]];
-
-(* special forms that are not supported *)
-ToPython::hasDerivative="Dervatives are not supported";
-PythonForm[Derivative[___]] := (Message[ToPython::hasDerivative]; Abort[]);
-
-(* Simple math *)
-PythonForm[Rational[a_, b_]] := ToString[N[a/b, $MachinePrecision], FortranForm];
-PythonForm[a_Rational] := ToString[N[a, $MachinePrecision], FortranForm];
-PythonForm[Complex[a_, b_]] := format["complex(``, ``)", a, b];
-PythonForm[a_ * b__] := Module[{fs, bl={b}},
-	fs = StringRiffle[ConstantArray["``", 1 + Length@bl], " * "];
-	format[fs, br@a, Sequence @@ br /@  bl]
-];
-PythonForm[a_ + b_] := format["`` + ``", a, b];
-PythonForm[Power[a_, b_]] := format["`` ** ``", br[a], br[b]];
-PythonForm[Exp[a_]] := format["numpy.exp(``)", a];
-
-(* Some basic functions *)
-PythonForm[Max[a_, b_]] := format["numpy.maximum(`1`, `2`)", a, b];
-PythonForm[Min[a_, b_]] := format["numpy.minimum(`1`, `2`)", a, b];
-
-(* Some special functions *)
-PythonForm[Arg[a_]] := format["numpy.angle(``)", a];
-PythonForm[SphericalHarmonicY[l_, m_, a_, b_]] := format[
-    "special.sph_harm(``, ``, (``) % (2 * numpy.pi), (``) % numpy.pi)",
-    m, l, b, a];
-PythonForm[Gamma[a_]] := format["special.gamma(``)", a];
-PythonForm[Gamma[a_, b_]] := format["special.gamma(`1`) * special.gammaincc(`1`, `2`)", a, b];
-PythonForm[BesselI[0, b_]] := format["special.i0(``)", b];
-PythonForm[BesselJ[0, b_]] := format["special.j0(``)", b];
-PythonForm[BesselK[0, b_]] := format["special.k0(``)", b];
-PythonForm[BesselY[0, b_]] := format["special.y0(``)", b];
-PythonForm[BesselI[1, b_]] := format["special.i1(``)", b];
-PythonForm[BesselJ[1, b_]] := format["special.j1(``)", b];
-PythonForm[BesselK[1, b_]] := format["special.k1(``)", b];
-PythonForm[BesselY[1, b_]] := format["special.y1(``)", b];
-PythonForm[BesselI[a_, b_]] := format["special.iv(``, ``)", a, b];
-PythonForm[BesselJ[a_, b_]] := format["special.jv(``, ``)", a, b];
-PythonForm[BesselK[a_, b_]] := format["special.kn(``, ``)", a, b];
-PythonForm[BesselY[a_, b_]] := format["special.yn(``, ``)", a, b];
-
-(* Some functions that are not defined in numpy *)
-PythonForm[Csc[a_]] := format["1 / numpy.sin(``)", a];
-PythonForm[Sec[a_]] := format["1 / numpy.cos(``)", a];
-PythonForm[Cot[a_]] := format["1 / numpy.tan(``)", a];
-PythonForm[Csch[a_]] := format["1 / numpy.sinh(``)", a];
-PythonForm[Sech[a_]] := format["1 / numpy.cosh(``)", a];
-PythonForm[Coth[a_]] := format["1 / numpy.tanh(``)", a];
-
-(* Handling arrays *)
-PythonForm[a_NumericArray] :=
-	np<>"array("<>StringReplace[ToString@Normal@a, {"{"-> "[", "}"-> "]"}]<>")";
-PythonForm[List[args__]] :=
-	np<>"array(["<>StringRiffle[PythonForm/@List[args], ", "]<>"])";
-
-(* Constants *)
-PythonForm[\[Pi]] = np<>"pi";
-PythonForm[E] = np<>"e";
-
-(* Greek characters *)
-greekrule={
-    "\[Alpha]"->"alpha","\[Beta]"->"beta","\[Gamma]"->"gamma","\[Delta]"->"delta",
-    "\[Epsilon]"->"epsilon", "\[CurlyEpsilon]"->"curlyepsilon","\[Zeta]"->"zeta","\[Eta]"->"eta",
-    "\[Theta]"->"theta","\[Iota]"->"iota","\[Kappa]"->"kappa","\[Lambda]"->"lambda",
-    "\[Mu]"->"mu","\[Nu]"->"nu","\[Xi]"->"xi","\[Omicron]"->"omicron","\[Pi]"->"pi",
-    "\[Rho]"->"rho","\[FinalSigma]"->"finalsigma","\[Sigma]"->"sigma","\[Tau]"->"tau",
-    "\[Upsilon]"->"upsilon","\[CurlyPhi]"->"curlyphi","\[Chi]"->"chi","\[Phi]" -> "phi",
-    "\[Psi]"->"psi",
-    "\[Omega]"->"omega","\[CapitalAlpha]"->"Alpha","\[CapitalBeta]"->"Beta",
-    "\[CapitalGamma]"->"Gamma","\[CapitalDelta]"->"Delta",
-    "\[CapitalEpsilon]"->"CurlyEpsilon","\[CapitalZeta]"->"Zeta",
-    "\[CapitalEta]"->"Eta","\[CapitalTheta]"->"Theta","\[CapitalIota]"->"Iota",
-    "\[CapitalKappa]"->"Kappa","\[CapitalLambda]"->"Lambda","\[CapitalMu]"->"Mu",
-    "\[CapitalNu]"->"Nu","\[CapitalXi]"->"Xi","\[CapitalOmicron]"->"Omicron",
-    "\[CapitalPi]"->"Pi","\[CapitalRho]"->"Rho","\[CapitalSigma]"->"Sigma",
-    "\[CapitalTau]"->"Tau","\[CapitalUpsilon]"->"Upsilon","\[CapitalPhi]"->"CurlyPhi",
-    "\[CapitalChi]"->"Chi","\[CapitalPsi]"->"Psi","\[CapitalOmega]"->"Omega"};
-
-(* Everything else *)
-PythonForm[h_[args__]] := np<>ToLowerCase[PythonForm[h]]<>"("<>PythonForm[args]<>")";
-PythonForm[allOther_] := StringReplace[ToString[allOther, FortranForm], greekrule];
-
-result = StringReplace[PythonForm[expression], greekrule];
-(* Copy results to clipboard *)
-If[copy, CopyToClipboard[result]];
-result
-]
-
-
-Options[ToPythonEquation] = {NumpyPrefix->"np", Copy->False};
-ToPythonEquation[Equal[a_, b_], opts : OptionsPattern[]] := ToPython[a - b, opts]
-
+ToPythonEquation[Equal[a_, b_], opts : OptionsPattern[]] :=
+    ToPython[a - b, opts]
 
 End[]
+
 EndPackage[]

--- a/ToPython_examples.nb
+++ b/ToPython_examples.nb
@@ -1,11 +1,13 @@
 (* Content-type: application/vnd.wolfram.mathematica *)
 
 (*** Wolfram Notebook File ***)
+
 (* http://www.wolfram.com/nb *)
 
 (* CreatedBy='Mathematica 11.0' *)
 
 (*CacheID: 234*)
+
 (* Internal cache information:
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
@@ -17,1575 +19,866 @@ CellTagsIndexPosition[     72463,       1586]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
-Notebook[{
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{
-    RowBox[{"loads", " ", "the", " ", "package"}], " ", "-", " ", 
-    RowBox[{"after", " ", "installation"}]}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{"Get", "@", 
-   RowBox[{"FileNameJoin", "[", 
-    RowBox[{"{", 
-     RowBox[{
-      RowBox[{"NotebookDirectory", "[", "]"}], ",", "\"\<ToPython.wl\>\""}], 
-     "}"}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.70181767476367*^9, 3.701817694205203*^9}, {
-  3.7018181976937943`*^9, 3.701818211998588*^9}, {3.817007877025469*^9, 
-  3.81700790447239*^9}, {3.8172214865707483`*^9, 3.81722149743857*^9}},
- CellLabel->"In[47]:=",ExpressionUUID->"ee6242fe-5738-42d7-927d-12c3be9f45f8"],
 
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{"?", "ToPython"}]], "Input",
- CellChangeTimes->{{3.70181815383568*^9, 3.7018181578773003`*^9}, 
-   3.701818214459565*^9, {3.817118303280854*^9, 3.817118304890544*^9}, {
-   3.8171204416196833`*^9, 3.8171204422649813`*^9}, {3.846041124797001*^9, 
-   3.846041134384152*^9}},
- CellLabel->"In[48]:=",ExpressionUUID->"e8858397-83ae-4bb9-9a33-1b677626ef0c"],
-
-Cell[BoxData[
- TemplateBox[{
-  "StringForm", "string", 
-   "\"String expected at position StandardForm[Short[Shallow[HoldForm[1], \
-{10, 50}], 5]] in StandardForm[Short[Shallow[HoldForm[StringForm[Private`s, \
-Sequence @@ Private`PythonForm /@ {Private`args}]], {10, 50}], 5]].\"", 2, 48,
-    1, 27837000086921606047, "Local"},
-  "MessageTemplate"]], "Message", "MSG",
- CellChangeTimes->{{3.846041131173876*^9, 3.8460411348863487`*^9}, 
-   3.846041288298971*^9, 3.846041712287074*^9, {3.84604174243005*^9, 
-   3.846041755722417*^9}, 3.8460418725700493`*^9, 3.84604234575531*^9, 
-   3.8464081244260674`*^9, 3.846408252278989*^9},
- CellLabel->
-  "During evaluation of \
-In[48]:=",ExpressionUUID->"8547ffc5-678a-4925-92f6-8ad83246e2a7"],
-
-Cell[BoxData[
- InterpretationBox[
-  StyleBox[
-   FrameBox[
-    DynamicModuleBox[{System`InformationDump`open$$ = False, 
-     System`InformationDump`mouseOver$$ = False}, 
-     PaneSelectorBox[{True->
-      TagBox[GridBox[{
-         {
-          ItemBox[
-           PaneBox[
-            StyleBox["\<\" Symbol\"\>", "InformationTitleText",
-             StripOnInput->False,
-             BaseStyle -> None],
-            FrameMargins->{{4, 0}, {-1, 1}}],
-           BaseStyle->"InformationTitleBackground",
-           StripOnInput->False], 
-          ItemBox["\<\"\"\>",
-           BaseStyle->"InformationTitleBackground",
-           StripOnInput->False]},
-         {
-          ItemBox[
-           PaneBox[
-            
-            StyleBox["\<\"ToPython[expression, NumpyPrefix->\\\"np\\\", \
-Copy->False]\\n\\tconverts Mathematica expression to a Numpy compatible \
-expression. Because Numpy can\\n\\tbe imported in several ways, you can \
-specify the name of the numpy module using the\\n    NumpyPrefix option. The \
-additional option Copy allows you to copy the result to the clipboard\"\>", 
-             "InformationUsageText",
-             StripOnInput->False,
-             LineSpacing->{1.5, 1.5, 3.}],
-            FrameMargins->{{10, 10}, {8, 10}}],
-           BaseStyle->"InformationUsageSubtitleBackground",
-           StripOnInput->False], 
-          ItemBox["\<\"\"\>",
-           BaseStyle->"InformationUsageSubtitleBackground",
-           StripOnInput->False]},
-         {
-          PaneBox[GridBox[{
-             {
-              
-              DynamicModuleBox[{System`InformationDump`open$$ = {
-               False, False, False, False, False, False, False, False, False, 
-                False, False, False}}, 
-               StyleBox[GridBox[{
-                  {
-                   TagBox[
-                    TooltipBox[
-                    StyleBox["\<\" Definitions\"\>", "InformationRowLabel",
-                    StripOnInput->False],
-                    "\"Definitions\"",
-                    TooltipStyle->"TextStyling"],
-                    Annotation[#, "Definitions", "Tooltip"]& ], GridBox[{
-                    {
-                    RowBox[{
-                    RowBox[{"ToPython", "[", 
-                    RowBox[{"Private`expression_", ",", 
-                    RowBox[{"OptionsPattern", "[", "]"}]}], "]"}], ":=", 
-                    RowBox[{"Module", "[", 
-                    RowBox[{
-                    RowBox[{"{", 
-                    RowBox[{
-                    RowBox[{"Private`numpyprefix", "=", 
-                    RowBox[{
-                    "OptionValue", "[", "Private`NumpyPrefix", "]"}]}], ",", 
-                    RowBox[{"Private`copy", "=", 
-                    RowBox[{"OptionValue", "[", "Private`Copy", "]"}]}], ",", 
-                    "Private`result", ",", "Private`greekrule", ",", 
-                    "Private`format", ",", "Private`PythonForm", ",", 
-                    "Private`np", ",", "Private`br", ",", "Private`brackets", 
-                    ",", "Private`a", ",", "Private`b", ",", "Private`l", ",",
-                     "Private`m", ",", "Private`args"}], "}"}], ",", 
-                    RowBox[{
-                    RowBox[{"If", "[", 
-                    RowBox[{
-                    RowBox[{"Private`numpyprefix", "\[Equal]", "\<\"\"\>"}], 
-                    ",", 
-                    RowBox[{"Private`np", "=", "Private`numpyprefix"}], ",", 
-                    RowBox[{"Private`np", "=", 
-                    RowBox[{"Private`numpyprefix", "<>", "\<\".\"\>"}]}]}], 
-                    "]"}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"Private`pattern_String", ",", "Private`args__"}],
-                     "]"}], ":=", 
-                    RowBox[{"Module", "[", 
-                    RowBox[{
-                    RowBox[{"{", "Private`s", "}"}], ",", 
-                    RowBox[{
-                    RowBox[{"Private`s", "=", 
-                    RowBox[{"StringReplace", "[", 
-                    RowBox[{"Private`pattern", ",", 
-                    RowBox[{"\<\"numpy.\"\>", "\[Rule]", "Private`np"}]}], 
-                    "]"}]}], ";", 
-                    RowBox[{"ToString", "[", 
-                    RowBox[{"StringForm", "[", 
-                    RowBox[{"Private`s", ",", 
-                    RowBox[{"Sequence", "@@", 
-                    RowBox[{"Private`PythonForm", "/@", 
-                    RowBox[{"{", "Private`args", "}"}]}]}]}], "]"}], 
-                    "]"}]}]}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`br", "[", "Private`a_", "]"}], ":=", 
-                    RowBox[{"If", "[", 
-                    RowBox[{
-                    RowBox[{
-                    RowBox[{"AtomQ", "[", "Private`a", "]"}], "||", 
-                    RowBox[{"MemberQ", "[", 
-                    RowBox[{"Private`singleFunctions", ",", 
-                    RowBox[{"Head", "[", "Private`a", "]"}]}], "]"}]}], ",", 
-                    "Private`a", ",", 
-                    RowBox[{"Private`brackets", "[", "Private`a", "]"}]}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Private`brackets", "[", "Private`a_", "]"}], 
-                    "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"(``)\"\>", ",", "Private`a"}], "]"}]}], ";", 
-                    
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"-", "Private`a_"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"-``\"\>", ",", 
-                    RowBox[{"Private`br", "[", "Private`a", "]"}]}], "]"}]}], 
-                    ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    SuperscriptBox["Private`a_", 
-                    RowBox[{"Rational", "[", 
-                    RowBox[{"1", ",", "2"}], "]"}]], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"numpy.sqrt(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    FractionBox["Private`a_", "Private`b_"], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"`` / ``\"\>", ",", 
-                    RowBox[{"Private`br", "[", "Private`a", "]"}], ",", 
-                    RowBox[{"Private`br", "[", "Private`b", "]"}]}], "]"}]}], 
-                    ";", 
-                    RowBox[{
-                    StyleBox[
-                    RowBox[{"ToPython", "::", "hasDerivative"}], 
-                    "MessageName"], 
-                    "=", "\<\"Dervatives are not supported\"\>"}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Derivative", "[", "___", "]"}], "]"}], ":=", 
-                    RowBox[{"(", 
-                    RowBox[{
-                    RowBox[{"Message", "[", 
-                    StyleBox[
-                    RowBox[{"ToPython", "::", "hasDerivative"}], 
-                    "MessageName"], "]"}], ";", 
-                    RowBox[{"Abort", "[", "]"}]}], ")"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Rational", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"ToString", "[", 
-                    RowBox[{
-                    RowBox[{"N", "[", 
-                    RowBox[{
-                    FractionBox["Private`a", "Private`b"], ",", 
-                    "$MachinePrecision"}], "]"}], ",", "FortranForm"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{
-                    "Private`PythonForm", "[", "Private`a_Rational", "]"}], ":=", 
-                    RowBox[{"ToString", "[", 
-                    RowBox[{
-                    RowBox[{"N", "[", 
-                    RowBox[{"Private`a", ",", "$MachinePrecision"}], "]"}], 
-                    ",", "FortranForm"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Complex", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"complex(``, ``)\"\>", ",", "Private`a", ",", 
-                    "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Private`a_", " ", "Private`b__"}], "]"}], ":=", 
-                    RowBox[{"Module", "[", 
-                    RowBox[{
-                    RowBox[{"{", 
-                    RowBox[{"Private`fs", ",", 
-                    RowBox[{"Private`bl", "=", 
-                    RowBox[{"{", "Private`b", "}"}]}]}], "}"}], ",", 
-                    RowBox[{
-                    RowBox[{"Private`fs", "=", 
-                    RowBox[{"StringRiffle", "[", 
-                    RowBox[{
-                    RowBox[{"ConstantArray", "[", 
-                    RowBox[{"\<\"``\"\>", ",", 
-                    RowBox[{"1", "+", 
-                    RowBox[{"Length", "[", "Private`bl", "]"}]}]}], "]"}], 
-                    ",", "\<\" * \"\>"}], "]"}]}], ";", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"Private`fs", ",", 
-                    RowBox[{"Private`br", "[", "Private`a", "]"}], ",", 
-                    RowBox[{"Sequence", "@@", 
-                    RowBox[{"Private`br", "/@", "Private`bl"}]}]}], "]"}]}]}],
-                     "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Private`a_", "+", "Private`b_"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"`` + ``\"\>", ",", "Private`a", ",", 
-                    "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    SuperscriptBox["Private`a_", "Private`b_"], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"`` ** ``\"\>", ",", 
-                    RowBox[{"Private`br", "[", "Private`a", "]"}], ",", 
-                    RowBox[{"Private`br", "[", "Private`b", "]"}]}], "]"}]}], 
-                    ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Exp", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"numpy.exp(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Max", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"numpy.maximum(`1`, `2`)\"\>", ",", 
-                    "Private`a", ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Min", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"numpy.minimum(`1`, `2`)\"\>", ",", 
-                    "Private`a", ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Arg", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"numpy.angle(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"SphericalHarmonicY", "[", 
-                    RowBox[{
-                    "Private`l_", ",", "Private`m_", ",", "Private`a_", ",", 
-                    "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"special.sph_harm(``, ``, (``) % (2 * \
-numpy.pi), (``) % numpy.pi)\"\>", ",", "Private`m", ",", "Private`l", ",", 
-                    "Private`b", ",", "Private`a"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Gamma", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.gamma(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Gamma", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"special.gamma(`1`) * special.gammaincc(`1`, \
-`2`)\"\>", ",", "Private`a", ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselI", "[", 
-                    RowBox[{"0", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.i0(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselJ", "[", 
-                    RowBox[{"0", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.j0(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselK", "[", 
-                    RowBox[{"0", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.k0(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselY", "[", 
-                    RowBox[{"0", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.y0(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselI", "[", 
-                    RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.i1(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselJ", "[", 
-                    RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.j1(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselK", "[", 
-                    RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.k1(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselY", "[", 
-                    RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"special.y1(``)\"\>", ",", "Private`b"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselI", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"special.iv(``, ``)\"\>", ",", "Private`a", 
-                    ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselJ", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"special.jv(``, ``)\"\>", ",", "Private`a", 
-                    ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselK", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"special.kn(``, ``)\"\>", ",", "Private`a", 
-                    ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"BesselY", "[", 
-                    RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    
-                    RowBox[{"\<\"special.yn(``, ``)\"\>", ",", "Private`a", 
-                    ",", "Private`b"}], "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Csc", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"1 / numpy.sin(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Sec", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"1 / numpy.cos(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Cot", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"1 / numpy.tan(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Csch", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"1 / numpy.sinh(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Sech", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"1 / numpy.cosh(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Coth", "[", "Private`a_", "]"}], "]"}], ":=", 
-                    RowBox[{"Private`format", "[", 
-                    RowBox[{"\<\"1 / numpy.tanh(``)\"\>", ",", "Private`a"}], 
-                    "]"}]}], ";", 
-                    RowBox[{
-                    RowBox[{
-                    "Private`PythonForm", "[", "Private`a_NumericArray", 
-                    "]"}], ":=", 
-                    RowBox[{"Private`np", "<>", "\<\"array(\"\>", "<>", 
-                    RowBox[{"StringReplace", "[", 
-                    RowBox[{
-                    RowBox[{"ToString", "[", 
-                    RowBox[{"Normal", "[", "Private`a", "]"}], "]"}], ",", 
-                    RowBox[{"{", 
-                    RowBox[{
-                    RowBox[{"\<\"{\"\>", "\[Rule]", "\<\"[\"\>"}], ",", 
-                    RowBox[{"\<\"}\"\>", "\[Rule]", "\<\"]\"\>"}]}], "}"}]}], 
-                    "]"}], "<>", "\<\")\"\>"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"{", "Private`args__", "}"}], "]"}], ":=", 
-                    RowBox[{"Private`np", "<>", "\<\"array([\"\>", "<>", 
-                    RowBox[{"StringRiffle", "[", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "/@", 
-                    RowBox[{"{", "Private`args", "}"}]}], ",", "\<\", \"\>"}],
-                     "]"}], "<>", "\<\"])\"\>"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", "\[Pi]", "]"}], "=", 
-                    RowBox[{"Private`np", "<>", "\<\"pi\"\>"}]}], ";", 
-                    RowBox[{
-                    RowBox[{
-                    "Private`PythonForm", "[", "\[ExponentialE]", "]"}], "=", 
-                    
-                    RowBox[{"Private`np", "<>", "\<\"e\"\>"}]}], ";", 
-                    RowBox[{"Private`greekrule", "=", 
-                    RowBox[{"{", 
-                    RowBox[{
-                    RowBox[{"\<\"\[Alpha]\"\>", "\[Rule]", "\<\"alpha\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Beta]\"\>", "\[Rule]", "\<\"beta\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Gamma]\"\>", "\[Rule]", "\<\"gamma\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Delta]\"\>", "\[Rule]", "\<\"delta\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[CurlyEpsilon]\"\>", 
-                    "\[Rule]", "\<\"curlyepsilon\"\>"}], ",", 
-                    RowBox[{"\<\"\[Zeta]\"\>", "\[Rule]", "\<\"zeta\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Eta]\"\>", "\[Rule]", "\<\"eta\"\>"}], ",", 
-                    RowBox[{"\<\"\[Theta]\"\>", "\[Rule]", "\<\"theta\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Iota]\"\>", "\[Rule]", "\<\"iota\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Kappa]\"\>", "\[Rule]", "\<\"kappa\"\>"}], 
-                    ",", 
-                    
-                    RowBox[{"\<\"\[Lambda]\"\>", 
-                    "\[Rule]", "\<\"lambda\"\>"}], ",", 
-                    RowBox[{"\<\"\[Mu]\"\>", "\[Rule]", "\<\"mu\"\>"}], ",", 
-                    RowBox[{"\<\"\[Nu]\"\>", "\[Rule]", "\<\"nu\"\>"}], ",", 
-                    RowBox[{"\<\"\[Xi]\"\>", "\[Rule]", "\<\"xi\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[Omicron]\"\>", 
-                    "\[Rule]", "\<\"omicron\"\>"}], ",", 
-                    RowBox[{"\<\"\[Pi]\"\>", "\[Rule]", "\<\"pi\"\>"}], ",", 
-                    RowBox[{"\<\"\[Rho]\"\>", "\[Rule]", "\<\"rho\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[FinalSigma]\"\>", 
-                    "\[Rule]", "\<\"finalsigma\"\>"}], ",", 
-                    RowBox[{"\<\"\[Sigma]\"\>", "\[Rule]", "\<\"sigma\"\>"}], 
-                    ",", 
-                    RowBox[{"\<\"\[Tau]\"\>", "\[Rule]", "\<\"tau\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[Upsilon]\"\>", 
-                    "\[Rule]", "\<\"upsilon\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CurlyPhi]\"\>", 
-                    "\[Rule]", "\<\"curlyphi\"\>"}], ",", 
-                    RowBox[{"\<\"\[Chi]\"\>", "\[Rule]", "\<\"chi\"\>"}], ",", 
-                    RowBox[{"\<\"\[Phi]\"\>", "\[Rule]", "\<\"phi\"\>"}], ",", 
-                    RowBox[{"\<\"\[Psi]\"\>", "\[Rule]", "\<\"psi\"\>"}], ",", 
-                    RowBox[{"\<\"\[Omega]\"\>", "\[Rule]", "\<\"omega\"\>"}], 
-                    ",", 
-                    
-                    RowBox[{"\<\"\[CapitalAlpha]\"\>", 
-                    "\[Rule]", "\<\"Alpha\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalBeta]\"\>", 
-                    "\[Rule]", "\<\"Beta\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalGamma]\"\>", 
-                    "\[Rule]", "\<\"Gamma\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalDelta]\"\>", 
-                    "\[Rule]", "\<\"Delta\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalEpsilon]\"\>", 
-                    "\[Rule]", "\<\"CurlyEpsilon\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalZeta]\"\>", 
-                    "\[Rule]", "\<\"Zeta\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalEta]\"\>", 
-                    "\[Rule]", "\<\"Eta\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalTheta]\"\>", 
-                    "\[Rule]", "\<\"Theta\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalIota]\"\>", 
-                    "\[Rule]", "\<\"Iota\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalKappa]\"\>", 
-                    "\[Rule]", "\<\"Kappa\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalLambda]\"\>", 
-                    "\[Rule]", "\<\"Lambda\"\>"}], ",", 
-                    RowBox[{"\<\"\[CapitalMu]\"\>", "\[Rule]", "\<\"Mu\"\>"}],
-                     ",", 
-                    RowBox[{"\<\"\[CapitalNu]\"\>", "\[Rule]", "\<\"Nu\"\>"}],
-                     ",", 
-                    RowBox[{"\<\"\[CapitalXi]\"\>", "\[Rule]", "\<\"Xi\"\>"}],
-                     ",", 
-                    
-                    RowBox[{"\<\"\[CapitalOmicron]\"\>", 
-                    "\[Rule]", "\<\"Omicron\"\>"}], ",", 
-                    RowBox[{"\<\"\[CapitalPi]\"\>", "\[Rule]", "\<\"Pi\"\>"}],
-                     ",", 
-                    
-                    RowBox[{"\<\"\[CapitalRho]\"\>", 
-                    "\[Rule]", "\<\"Rho\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalSigma]\"\>", 
-                    "\[Rule]", "\<\"Sigma\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalTau]\"\>", 
-                    "\[Rule]", "\<\"Tau\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalUpsilon]\"\>", 
-                    "\[Rule]", "\<\"Upsilon\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalPhi]\"\>", 
-                    "\[Rule]", "\<\"CurlyPhi\"\>"}], ",", 
-                    RowBox[{"\<\"\[CapitalChi]\"\>", 
-                    "\[Rule]", "\<\"Chi\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalPsi]\"\>", 
-                    "\[Rule]", "\<\"Psi\"\>"}], ",", 
-                    
-                    RowBox[{"\<\"\[CapitalOmega]\"\>", 
-                    "\[Rule]", "\<\"Omega\"\>"}]}], "}"}]}], ";", 
-                    RowBox[{
-                    RowBox[{"Private`PythonForm", "[", 
-                    RowBox[{"Private`h_", "[", "Private`args__", "]"}], "]"}],
-                     ":=", 
-                    RowBox[{"Private`np", "<>", 
-                    RowBox[{"ToLowerCase", "[", 
-                    RowBox[{"Private`PythonForm", "[", "Private`h", "]"}], 
-                    "]"}], "<>", "\<\"(\"\>", "<>", 
-                    RowBox[{"Private`PythonForm", "[", "Private`args", "]"}], 
-                    "<>", "\<\")\"\>"}]}], ";", 
-                    RowBox[{
-                    RowBox[{
-                    "Private`PythonForm", "[", "Private`allOther_", "]"}], ":=", 
-                    RowBox[{"StringReplace", "[", 
-                    RowBox[{
-                    RowBox[{"ToString", "[", 
-                    RowBox[{"Private`allOther", ",", "FortranForm"}], "]"}], 
-                    ",", "Private`greekrule"}], "]"}]}], ";", 
-                    RowBox[{"Private`result", "=", 
-                    RowBox[{"StringReplace", "[", 
-                    RowBox[{
-                    RowBox[{
-                    "Private`PythonForm", "[", "Private`expression", "]"}], 
-                    ",", "Private`greekrule"}], "]"}]}], ";", 
-                    RowBox[{"If", "[", 
-                    RowBox[{"Private`copy", ",", 
-                    RowBox[{"CopyToClipboard", "[", "Private`result", "]"}]}],
-                     "]"}], ";", "Private`result"}]}], "]"}]}]}
-                    },
-                    DefaultBaseStyle->"Column",
-                    GridBoxAlignment->{"Columns" -> {{Left}}},
-                    
-                    GridBoxItemSize->{
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]},
-                  {
-                   TagBox[
-                    TooltipBox[
-                    StyleBox["\<\" Options\"\>", "InformationRowLabel",
-                    StripOnInput->False],
-                    "\"Options\"",
-                    TooltipStyle->"TextStyling"],
-                    Annotation[#, "Options", "Tooltip"]& ], 
-                   RowBox[{"{", 
-                    RowBox[{
-                    RowBox[{"Private`NumpyPrefix", "\[Rule]", "\<\"np\"\>"}], 
-                    ",", 
-                    RowBox[{"Private`Copy", "\[Rule]", "False"}]}], "}"}]},
-                  {
-                   TagBox[
-                    TooltipBox[
-                    StyleBox["\<\" Full Name\"\>", "InformationRowLabel",
-                    StripOnInput->False],
-                    "\"FullName\"",
-                    TooltipStyle->"TextStyling"],
-                    
-                    Annotation[#, "FullName", 
-                    "Tooltip"]& ], "\<\"ToPython`ToPython\"\>"}
-                 },
-                 AutoDelete->False,
-                 GridBoxAlignment->{"Columns" -> {Right, Left}},
-                 GridBoxDividers->None,
-                 GridBoxItemSize->{"Columns" -> {Automatic, Automatic}},
-                 GridBoxSpacings->{"Columns" -> {
-                    Offset[0.27999999999999997`], {
-                    Offset[0.5599999999999999]}, 
-                    Offset[0.27999999999999997`]}, "Rows" -> {
-                    Offset[0.2], {
-                    Offset[0.8]}, 
-                    Offset[0.2]}}], "DialogStyle",
-                StripOnInput->False],
-               DynamicModuleValues:>{}]}
-            },
-            DefaultBaseStyle->"Column",
-            GridBoxAlignment->{"Columns" -> {{Left}}},
-            GridBoxDividers->{"Columns" -> {{False}}, "Rows" -> {{False}}},
-            
-            GridBoxItemSize->{
-             "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}},
-            GridBoxSpacings->{"Columns" -> {
-                Offset[0.27999999999999997`], {
-                 Offset[0.5599999999999999]}, 
-                Offset[0.27999999999999997`]}, "Rows" -> {
-                Offset[0.2], {
-                 Offset[3.6]}, 
-                Offset[0.2]}}],
-           FrameMargins->6], ""},
-         {
-          ItemBox[
-           TagBox[
-            ButtonBox[
-             PaneSelectorBox[{False->
-              
-              DynamicBox[FEPrivate`FrontEndResource[
-               "FEBitmaps", "UpPointerOpener"]], True->
-              
-              DynamicBox[FEPrivate`FrontEndResource[
-               "FEBitmaps", "UpPointerOpenerHot"]]}, Dynamic[
-              System`InformationDump`mouseOver$$]],
-             Alignment->Left,
-             Appearance->{"Default" -> None},
-             
-             ButtonFunction:>FEPrivate`Set[
-              System`InformationDump`open$$, False],
-             Evaluator->Automatic,
-             FrameMargins->{{9, 0}, {0, 0}},
-             ImageMargins->0,
-             ImageSize->Full,
-             Method->"Preemptive"],
-            
-            EventHandlerTag[{
-             "MouseEntered" :> 
-              FEPrivate`Set[System`InformationDump`mouseOver$$, True], 
-              "MouseExited" :> 
-              FEPrivate`Set[System`InformationDump`mouseOver$$, False], 
-              Method -> "Preemptive", PassEventsDown -> Automatic, 
-              PassEventsUp -> True}]],
-           BaseStyle->"InformationTitleBackground",
-           StripOnInput->False], "\[SpanFromLeft]"}
-        },
-        AutoDelete->False,
-        FrameStyle->Directive[
-          GrayLevel[0.8], 
-          Thickness[Tiny]],
-        GridBoxAlignment->{"Columns" -> {Left, Right}, "Rows" -> {{Center}}},
-        GridBoxDividers->{
-         "Columns" -> {{None}}, "Rows" -> {False, {True}, False}},
-        GridBoxItemSize->{
-         "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
-       "Grid"], False->
-      TagBox[GridBox[{
-         {
-          ItemBox[
-           PaneBox[
-            StyleBox["\<\" Symbol\"\>", "InformationTitleText",
-             StripOnInput->False],
-            FrameMargins->{{4, 0}, {-1, 1}}],
-           BaseStyle->"InformationTitleBackground",
-           StripOnInput->False], 
-          ItemBox["\<\"\"\>",
-           BaseStyle->"InformationTitleBackground",
-           StripOnInput->False]},
-         {
-          ItemBox[
-           PaneBox[
-            
-            StyleBox["\<\"ToPython[expression, NumpyPrefix->\\\"np\\\", \
-Copy->False]\\n\\tconverts Mathematica expression to a Numpy compatible \
-expression. Because Numpy can\\n\\tbe imported in several ways, you can \
-specify the name of the numpy module using the\\n    NumpyPrefix option. The \
-additional option Copy allows you to copy the result to the clipboard\"\>", 
-             "InformationUsageText",
-             StripOnInput->False,
-             LineSpacing->{1.5, 1.5, 3.}],
-            FrameMargins->{{10, 10}, {8, 10}}],
-           BaseStyle->"InformationUsageSubtitleBackground",
-           StripOnInput->False], 
-          ItemBox["\<\"\"\>",
-           BaseStyle->"InformationUsageSubtitleBackground",
-           StripOnInput->False]},
-         {
-          ItemBox[
-           TagBox[
-            ButtonBox[
-             PaneSelectorBox[{False->
-              
-              DynamicBox[FEPrivate`FrontEndResource[
-               "FEBitmaps", "DownPointerOpener"],
-               ImageSizeCache->{10., {2., 8.}}], True->
-              
-              DynamicBox[FEPrivate`FrontEndResource[
-               "FEBitmaps", "DownPointerOpenerHot"],
-               ImageSizeCache->{10., {2., 8.}}]}, Dynamic[
-              System`InformationDump`mouseOver$$]],
-             Alignment->Left,
-             Appearance->{"Default" -> None},
-             
-             ButtonFunction:>FEPrivate`Set[
-              System`InformationDump`open$$, True],
-             Evaluator->Automatic,
-             FrameMargins->{{9, 0}, {0, 0}},
-             ImageMargins->0,
-             ImageSize->Full,
-             Method->"Preemptive"],
-            
-            EventHandlerTag[{
-             "MouseEntered" :> 
-              FEPrivate`Set[System`InformationDump`mouseOver$$, True], 
-              "MouseExited" :> 
-              FEPrivate`Set[System`InformationDump`mouseOver$$, False], 
-              Method -> "Preemptive", PassEventsDown -> Automatic, 
-              PassEventsUp -> True}]],
-           BaseStyle->"InformationTitleBackground",
-           StripOnInput->False], "\[SpanFromLeft]"}
-        },
-        AutoDelete->False,
-        FrameStyle->Directive[
-          GrayLevel[0.8], 
-          Thickness[Tiny]],
-        GridBoxAlignment->{"Columns" -> {Left, Right}, "Rows" -> {{Center}}},
-        GridBoxDividers->{
-         "Columns" -> {{None}}, "Rows" -> {False, {True}, False}},
-        GridBoxItemSize->{
-         "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
-       "Grid"]}, Dynamic[System`InformationDump`open$$],
-      BaselinePosition->Baseline,
-      FrameMargins->0,
-      ImageSize->Automatic],
-     DynamicModuleValues:>{}],
-    BaseStyle->"InformationGridFrame",
-    StripOnInput->False], "InformationGridPlain",
-   StripOnInput->False],
-  InformationData[
-   Association[
-   "ObjectType" -> "Symbol", "Usage" -> 
-    "ToPython[expression, NumpyPrefix->\"np\", Copy->False]\n\tconverts \
-Mathematica expression to a Numpy compatible expression. Because Numpy can\n\t\
-be imported in several ways, you can specify the name of the numpy module \
-using the\n    NumpyPrefix option. The additional option Copy allows you to \
-copy the result to the clipboard", "Documentation" -> None, "OwnValues" -> 
-    None, "UpValues" -> None, "DownValues" -> 
-    Information`InformationValueForm[
-     DownValues, ToPython`ToPython, {ToPython`ToPython[
-         Pattern[Private`expression, 
-          Blank[]], 
-         OptionsPattern[]] :> 
-       Module[{Private`numpyprefix = OptionValue[Private`NumpyPrefix], 
-          Private`copy = OptionValue[Private`Copy], Private`result, 
-          Private`greekrule, Private`format, Private`PythonForm, Private`np, 
-          Private`br, Private`brackets, Private`a, Private`b, Private`l, 
-          Private`m, Private`args}, 
-         If[
-          Private`numpyprefix == "", Private`np = Private`numpyprefix, 
-           Private`np = StringJoin[Private`numpyprefix, "."]]; 
-         Private`format[
-            Pattern[Private`pattern, 
-             Blank[String]], 
-            Pattern[Private`args, 
-             BlankSequence[]]] := 
-          Module[{Private`s}, 
-            Private`s = 
-             StringReplace[Private`pattern, "numpy." -> Private`np]; 
-            ToString[
-              StringForm[Private`s, 
-               Apply[Sequence, 
-                Map[Private`PythonForm, {Private`args}]]]]]; Private`br[
-            Pattern[Private`a, 
-             Blank[]]] := If[
-            Or[
-             AtomQ[Private`a], 
-             MemberQ[Private`singleFunctions, 
-              Head[Private`a]]], Private`a, 
-            Private`brackets[Private`a]]; Private`PythonForm[
-            Private`brackets[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["(``)", Private`a]; 
-         Private`PythonForm[-Pattern[Private`a, 
-              Blank[]]] := Private`format["-``", 
-            Private`br[Private`a]]; Private`PythonForm[Pattern[Private`a, 
-              Blank[]]^Rational[1, 2]] := 
-          Private`format["numpy.sqrt(``)", Private`a]; 
-         Private`PythonForm[Pattern[Private`a, 
-              Blank[]]/Pattern[Private`b, 
-             Blank[]]] := Private`format["`` / ``", 
-            Private`br[Private`a], 
-            Private`br[Private`b]]; 
-         MessageName[ToPython`ToPython, "hasDerivative"] = 
-          "Dervatives are not supported"; Private`PythonForm[
-            Derivative[
-             BlankNullSequence[]]] := (Message[
-             MessageName[ToPython`ToPython, "hasDerivative"]]; Abort[]); 
-         Private`PythonForm[
-            Rational[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := ToString[
-            N[Private`a/Private`b, $MachinePrecision], FortranForm]; 
-         Private`PythonForm[
-            Pattern[Private`a, 
-             Blank[Rational]]] := ToString[
-            N[Private`a, $MachinePrecision], FortranForm]; 
-         Private`PythonForm[
-            Complex[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["complex(``, ``)", Private`a, Private`b]; 
-         Private`PythonForm[Pattern[Private`a, 
-              Blank[]] Pattern[Private`b, 
-              BlankSequence[]]] := 
-          Module[{Private`fs, Private`bl = {Private`b}}, 
-            Private`fs = StringRiffle[
-               ConstantArray["``", 1 + Length[Private`bl]], " * "]; 
-            Private`format[Private`fs, 
-              Private`br[Private`a], 
-              Apply[Sequence, 
-               Map[Private`br, Private`bl]]]]; 
-         Private`PythonForm[Pattern[Private`a, 
-              Blank[]] + Pattern[Private`b, 
-              Blank[]]] := Private`format["`` + ``", Private`a, Private`b]; 
-         Private`PythonForm[Pattern[Private`a, 
-              Blank[]]^Pattern[Private`b, 
-              Blank[]]] := Private`format["`` ** ``", 
-            Private`br[Private`a], 
-            Private`br[Private`b]]; Private`PythonForm[
-            Exp[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["numpy.exp(``)", Private`a]; 
-         Private`PythonForm[
-            Max[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["numpy.maximum(`1`, `2`)", Private`a, Private`b]; 
-         Private`PythonForm[
-            Min[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["numpy.minimum(`1`, `2`)", Private`a, Private`b]; 
-         Private`PythonForm[
-            Arg[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["numpy.angle(``)", Private`a]; 
-         Private`PythonForm[
-            SphericalHarmonicY[
-             Pattern[Private`l, 
-              Blank[]], 
-             Pattern[Private`m, 
-              Blank[]], 
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format[
-           "special.sph_harm(``, ``, (``) % (2 * numpy.pi), (``) % numpy.pi)",
-             Private`m, Private`l, Private`b, Private`a]; Private`PythonForm[
-            Gamma[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["special.gamma(``)", Private`a]; 
-         Private`PythonForm[
-            Gamma[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format[
-           "special.gamma(`1`) * special.gammaincc(`1`, `2`)", Private`a, 
-            Private`b]; Private`PythonForm[
-            BesselI[0, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.i0(``)", Private`b]; 
-         Private`PythonForm[
-            BesselJ[0, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.j0(``)", Private`b]; 
-         Private`PythonForm[
-            BesselK[0, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.k0(``)", Private`b]; 
-         Private`PythonForm[
-            BesselY[0, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.y0(``)", Private`b]; 
-         Private`PythonForm[
-            BesselI[1, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.i1(``)", Private`b]; 
-         Private`PythonForm[
-            BesselJ[1, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.j1(``)", Private`b]; 
-         Private`PythonForm[
-            BesselK[1, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.k1(``)", Private`b]; 
-         Private`PythonForm[
-            BesselY[1, 
-             Pattern[Private`b, 
-              Blank[]]]] := Private`format["special.y1(``)", Private`b]; 
-         Private`PythonForm[
-            BesselI[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["special.iv(``, ``)", Private`a, Private`b]; 
-         Private`PythonForm[
-            BesselJ[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["special.jv(``, ``)", Private`a, Private`b]; 
-         Private`PythonForm[
-            BesselK[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["special.kn(``, ``)", Private`a, Private`b]; 
-         Private`PythonForm[
-            BesselY[
-             Pattern[Private`a, 
-              Blank[]], 
-             Pattern[Private`b, 
-              Blank[]]]] := 
-          Private`format["special.yn(``, ``)", Private`a, Private`b]; 
-         Private`PythonForm[
-            Csc[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["1 / numpy.sin(``)", Private`a]; 
-         Private`PythonForm[
-            Sec[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["1 / numpy.cos(``)", Private`a]; 
-         Private`PythonForm[
-            Cot[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["1 / numpy.tan(``)", Private`a]; 
-         Private`PythonForm[
-            Csch[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["1 / numpy.sinh(``)", Private`a]; 
-         Private`PythonForm[
-            Sech[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["1 / numpy.cosh(``)", Private`a]; 
-         Private`PythonForm[
-            Coth[
-             Pattern[Private`a, 
-              Blank[]]]] := Private`format["1 / numpy.tanh(``)", Private`a]; 
-         Private`PythonForm[
-            Pattern[Private`a, 
-             Blank[NumericArray]]] := StringJoin[Private`np, "array(", 
-            StringReplace[
-             ToString[
-              Normal[Private`a]], {"{" -> "[", "}" -> "]"}], ")"]; 
-         Private`PythonForm[{
-             Pattern[Private`args, 
-              BlankSequence[]]}] := StringJoin[Private`np, "array([", 
-            StringRiffle[
-             Map[Private`PythonForm, {Private`args}], ", "], "])"]; 
-         Private`PythonForm[Pi] = StringJoin[Private`np, "pi"]; 
-         Private`PythonForm[E] = StringJoin[Private`np, "e"]; 
-         Private`greekrule = {
-           "\[Alpha]" -> "alpha", "\[Beta]" -> "beta", "\[Gamma]" -> "gamma", 
-            "\[Delta]" -> "delta", "\[CurlyEpsilon]" -> "curlyepsilon", 
-            "\[Zeta]" -> "zeta", "\[Eta]" -> "eta", "\[Theta]" -> "theta", 
-            "\[Iota]" -> "iota", "\[Kappa]" -> "kappa", "\[Lambda]" -> 
-            "lambda", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", 
-            "\[Omicron]" -> "omicron", "\[Pi]" -> "pi", "\[Rho]" -> "rho", 
-            "\[FinalSigma]" -> "finalsigma", "\[Sigma]" -> "sigma", "\[Tau]" -> 
-            "tau", "\[Upsilon]" -> "upsilon", "\[CurlyPhi]" -> "curlyphi", 
-            "\[Chi]" -> "chi", "\[Phi]" -> "phi", "\[Psi]" -> "psi", 
-            "\[Omega]" -> "omega", "\[CapitalAlpha]" -> "Alpha", 
-            "\[CapitalBeta]" -> "Beta", "\[CapitalGamma]" -> "Gamma", 
-            "\[CapitalDelta]" -> "Delta", "\[CapitalEpsilon]" -> 
-            "CurlyEpsilon", "\[CapitalZeta]" -> "Zeta", "\[CapitalEta]" -> 
-            "Eta", "\[CapitalTheta]" -> "Theta", "\[CapitalIota]" -> "Iota", 
-            "\[CapitalKappa]" -> "Kappa", "\[CapitalLambda]" -> "Lambda", 
-            "\[CapitalMu]" -> "Mu", "\[CapitalNu]" -> "Nu", "\[CapitalXi]" -> 
-            "Xi", "\[CapitalOmicron]" -> "Omicron", "\[CapitalPi]" -> "Pi", 
-            "\[CapitalRho]" -> "Rho", "\[CapitalSigma]" -> "Sigma", 
-            "\[CapitalTau]" -> "Tau", "\[CapitalUpsilon]" -> "Upsilon", 
-            "\[CapitalPhi]" -> "CurlyPhi", "\[CapitalChi]" -> "Chi", 
-            "\[CapitalPsi]" -> "Psi", "\[CapitalOmega]" -> "Omega"}; 
-         Private`PythonForm[
-            Pattern[Private`h, 
-             Blank[]][
-             Pattern[Private`args, 
-              BlankSequence[]]]] := StringJoin[Private`np, 
-            ToLowerCase[
-             Private`PythonForm[Private`h]], "(", 
-            Private`PythonForm[Private`args], ")"]; Private`PythonForm[
-            Pattern[Private`allOther, 
-             Blank[]]] := StringReplace[
-            ToString[Private`allOther, FortranForm], Private`greekrule]; 
-         Private`result = StringReplace[
-            Private`PythonForm[Private`expression], Private`greekrule]; 
-         If[Private`copy, 
-           CopyToClipboard[Private`result]]; Private`result]}], "SubValues" -> 
-    None, "DefaultValues" -> None, "NValues" -> None, "FormatValues" -> None, 
-    "Options" -> {Private`NumpyPrefix -> "np", Private`Copy -> False}, 
-    "Attributes" -> {}, "FullName" -> "ToPython`ToPython"], False]]], "Output",\
-
- CellChangeTimes->{{3.846041131188478*^9, 3.846041134941896*^9}, 
-   3.846041288348984*^9, 3.846041712356203*^9, {3.846041742478557*^9, 
-   3.846041755771311*^9}, 3.846041872618247*^9, 3.8460423457875566`*^9, 
-   3.846408124469769*^9, 3.8464082522938833`*^9},
- CellLabel->"Out[48]=",ExpressionUUID->"42c28b92-2b81-493e-bb74-e25330a1fff5"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", " ", "Numbers", " ", "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ToPython", "[", 
-    RowBox[{"1", "/", "2"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"1", "/", "3"}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.846041020933352*^9, 3.8460410297347317`*^9}, {
-  3.846041760995372*^9, 3.846041764297275*^9}, {3.846041864881761*^9, 
-  3.846041865835989*^9}},
- CellLabel->"In[50]:=",ExpressionUUID->"d17288e2-6b59-4b37-b3ab-c96969989f11"],
-
-Cell[BoxData["\<\"0.5\"\>"], "Output",
- CellChangeTimes->{{3.846041025718354*^9, 3.8460410689851227`*^9}, 
-   3.846041161606009*^9, 3.846041713588273*^9, {3.8460417559319*^9, 
-   3.846041768151883*^9}, 3.846041872624201*^9, 3.846042345795823*^9, 
-   3.846408252327827*^9},
- CellLabel->"Out[50]=",ExpressionUUID->"a735febf-e560-43bd-bd6d-f914d64a4827"],
-
-Cell[BoxData["\<\"0.3333333333333333\"\>"], "Output",
- CellChangeTimes->{{3.846041025718354*^9, 3.8460410689851227`*^9}, 
-   3.846041161606009*^9, 3.846041713588273*^9, {3.8460417559319*^9, 
-   3.846041768151883*^9}, 3.846041872624201*^9, 3.846042345795823*^9, 
-   3.846408252329979*^9},
- CellLabel->"Out[51]=",ExpressionUUID->"acd027db-6e0c-4cf4-b716-fb0f2df127e2"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{"Expression", " ", "examples"}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ToPython", "[", 
-    RowBox[{"a", "+", "b"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"a", "*", "b", "*", "c"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"a", "/", "b"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"(", 
-      RowBox[{"a", "+", "b"}], ")"}], "/", 
-     RowBox[{"(", 
-      RowBox[{"d", "+", "e", "+", "g"}], ")"}]}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"(", 
-      RowBox[{"a", "+", "b"}], ")"}], "^", 
-     RowBox[{"(", 
-      RowBox[{"d", "+", "e", "+", "g"}], ")"}]}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"Exp", "[", 
-     RowBox[{"a", "+", "b"}], "]"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"Sin", "[", 
-      RowBox[{"(", 
-       RowBox[{"a", "+", "b"}], ")"}], "]"}], "/", 
-     RowBox[{"Cos", "[", 
-      RowBox[{"d", "+", "e"}], "]"}]}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"Sin", "[", 
-      RowBox[{"(", 
-       RowBox[{"a", "+", "b"}], ")"}], "]"}], "/", 
-     RowBox[{"Tanh", "[", 
-      RowBox[{"d", "+", "e"}], "]"}]}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"\[Pi]", " ", 
-     RowBox[{"Cosh", "[", "a", "]"}]}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"Log10", "[", "x", "]"}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.8170418609071417`*^9, 3.817041872218865*^9}, {3.82438092026691*^9, 
-  3.824380924710678*^9}, {3.824381208382967*^9, 3.824381214615004*^9}},
- CellLabel->"In[52]:=",ExpressionUUID->"740923fd-dd9e-45ca-b781-36fcddb044a7"],
-
-Cell[BoxData["\<\"a + b\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252358556*^9},
- CellLabel->"Out[52]=",ExpressionUUID->"88214388-71e3-462b-a5be-66420571aab7"],
-
-Cell[BoxData["\<\"a * b * c\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252359899*^9},
- CellLabel->"Out[53]=",ExpressionUUID->"0023fa9a-51c8-4c11-b552-d32e67f3707f"],
-
-Cell[BoxData["\<\"a / b\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.8464082523613157`*^9},
- CellLabel->"Out[54]=",ExpressionUUID->"4273074a-af87-41ce-9cc6-ae203b991c32"],
-
-Cell[BoxData["\<\"(a + b) / (d + e + g)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252362858*^9},
- CellLabel->"Out[55]=",ExpressionUUID->"bb9155fa-3227-43c3-a10a-f5d16b7cd372"],
-
-Cell[BoxData["\<\"(a + b) ** (d + e + g)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252364133*^9},
- CellLabel->"Out[56]=",ExpressionUUID->"d7158797-1d4f-401d-bb64-c29b2496c672"],
-
-Cell[BoxData["\<\"np.exp(a + b)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.84640825236545*^9},
- CellLabel->"Out[57]=",ExpressionUUID->"e81953d6-e02b-4b0e-b543-bad8760a8b3b"],
-
-Cell[BoxData["\<\"(1 / np.cos(d + e)) * np.sin(a + b)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252366715*^9},
- CellLabel->"Out[58]=",ExpressionUUID->"9a3c9c1d-3be9-4fb8-9a18-14e65e057788"],
-
-Cell[BoxData["\<\"(1 / np.tanh(d + e)) * np.sin(a + b)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252368518*^9},
- CellLabel->"Out[59]=",ExpressionUUID->"e6d1f67c-7b2c-46c4-b5c9-122bbd12864b"],
-
-Cell[BoxData["\<\"np.pi * np.cosh(a)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.8464082523698797`*^9},
- CellLabel->"Out[60]=",ExpressionUUID->"f275590b-eaf0-4e44-b675-c92fb2ebc858"],
-
-Cell[BoxData["\<\"np.log(x) / np.log(10)\"\>"], "Output",
- CellChangeTimes->{
-  3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9}, 
-   3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9}, 
-   3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9, 
-   3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {
-   3.84604101911229*^9, 3.8460410406669703`*^9}, 3.8460418726579113`*^9, 
-   3.846042345821651*^9, 3.846408252371305*^9},
- CellLabel->"Out[61]=",ExpressionUUID->"caf70baa-78be-4c50-8a77-f181a689e36f"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{"Expression", " ", "with", " ", "greek", " ", "letters"}], "*)"}], 
-  "\[IndentingNewLine]", 
-  RowBox[{"ToPython", "[", 
-   RowBox[{"Sin", "[", 
-    RowBox[{"\[Alpha]", "+", "\[Beta]"}], "]"}], "]"}]}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.817020691587697*^9, 3.817020708510957*^9}, 3.817041875624913*^9},
- CellLabel->"In[62]:=",ExpressionUUID->"d695df00-d1d2-4318-b649-f671d424864e"],
-
-Cell[BoxData["\<\"np.sin(alpha + beta)\"\>"], "Output",
- CellChangeTimes->{{3.834825430723674*^9, 3.834825457528077*^9}, 
-   3.8348254947234497`*^9, 3.8348256558938103`*^9, 3.8460418726745653`*^9, 
-   3.846042345838647*^9, 3.846408252378503*^9},
- CellLabel->"Out[62]=",ExpressionUUID->"36ad64db-329f-490b-b04e-505146c262de"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{"Numeric", " ", "examples"}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ToPython", "[", "2", "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"1", "/", "3"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"1.0", "/", "3"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", "2.31", "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"2.31", "+", 
-     RowBox[{"5.3", "I"}]}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}},
- CellLabel->"In[63]:=",ExpressionUUID->"5185dd86-dec4-4c26-8e48-124321882ccc"],
-
-Cell[BoxData["\<\"2\"\>"], "Output",
- CellChangeTimes->{{3.8348254307300167`*^9, 3.834825457566633*^9}, 
-   3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9, 
-   3.8460423458778563`*^9, 3.846408252420711*^9},
- CellLabel->"Out[63]=",ExpressionUUID->"34ff0311-ced8-4ed5-9f19-3c5c313b48f6"],
-
-Cell[BoxData["\<\"0.3333333333333333\"\>"], "Output",
- CellChangeTimes->{{3.8348254307300167`*^9, 3.834825457566633*^9}, 
-   3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9, 
-   3.8460423458778563`*^9, 3.846408252422104*^9},
- CellLabel->"Out[64]=",ExpressionUUID->"ff1f2ab9-65bf-440e-b271-3b059595e619"],
-
-Cell[BoxData["\<\"0.3333333333333333\"\>"], "Output",
- CellChangeTimes->{{3.8348254307300167`*^9, 3.834825457566633*^9}, 
-   3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9, 
-   3.8460423458778563`*^9, 3.846408252423403*^9},
- CellLabel->"Out[65]=",ExpressionUUID->"6fc6c7d0-110c-40e4-8004-48f597b8237b"],
-
-Cell[BoxData["\<\"2.31\"\>"], "Output",
- CellChangeTimes->{{3.8348254307300167`*^9, 3.834825457566633*^9}, 
-   3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9, 
-   3.8460423458778563`*^9, 3.846408252424692*^9},
- CellLabel->"Out[66]=",ExpressionUUID->"5eba5c6f-d861-48ec-a19b-61235d4295b0"],
-
-Cell[BoxData["\<\"complex(2.31, 5.3)\"\>"], "Output",
- CellChangeTimes->{{3.8348254307300167`*^9, 3.834825457566633*^9}, 
-   3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9, 
-   3.8460423458778563`*^9, 3.846408252426001*^9},
- CellLabel->"Out[67]=",ExpressionUUID->"663903c8-b170-4217-9afb-bef9f743e2c2"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{"Array", " ", "handling"}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ToPython", "[", 
-    RowBox[{"{", 
-     RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"{", 
-     RowBox[{"{", 
-      RowBox[{"1", ",", "2", ",", "3"}], "}"}], "}"}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{"Cos", "[", 
-     RowBox[{"{", 
-      RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020703952483*^9}, {3.817042042716785*^9, 
-  3.817042043976235*^9}},
- CellLabel->"In[68]:=",ExpressionUUID->"292185a9-2fb5-4cee-ba04-979e10b4d536"],
-
-Cell[BoxData["\<\"np.array([1, 2, 3])\"\>"], "Output",
- CellChangeTimes->{{3.834825430781938*^9, 3.834825457577856*^9}, 
-   3.834825494779072*^9, 3.834825655944306*^9, 3.846041872722941*^9, 
-   3.846042345888381*^9, 3.84640825243394*^9},
- CellLabel->"Out[68]=",ExpressionUUID->"0112898f-b97d-40ac-bad5-e08df00d59e5"],
-
-Cell[BoxData["\<\"np.array([np.array([1, 2, 3])])\"\>"], "Output",
- CellChangeTimes->{{3.834825430781938*^9, 3.834825457577856*^9}, 
-   3.834825494779072*^9, 3.834825655944306*^9, 3.846041872722941*^9, 
-   3.846042345888381*^9, 3.846408252436035*^9},
- CellLabel->"Out[69]=",ExpressionUUID->"2b10b530-5d6c-45a1-a3d1-849cbde2b60f"],
-
-Cell[BoxData["\<\"np.array([np.cos(1), np.cos(2), np.cos(3)])\"\>"], "Output",
- CellChangeTimes->{{3.834825430781938*^9, 3.834825457577856*^9}, 
-   3.834825494779072*^9, 3.834825655944306*^9, 3.846041872722941*^9, 
-   3.846042345888381*^9, 3.8464082524375343`*^9},
- CellLabel->"Out[70]=",ExpressionUUID->"7147813f-8b02-496b-9047-a3c10754db26"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{"Example", " ", "with", " ", "numpy", " ", "as", " ", "numpy"}], 
-   "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"\[Pi]", " ", 
-      RowBox[{
-       RowBox[{"Cosh", "[", "a", "]"}], "/", 
-       RowBox[{"Sin", "[", "b", "]"}]}]}], ",", 
-     RowBox[{"NumpyPrefix", "\[Rule]", " ", "\"\<numpy\>\""}]}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"Exp", "[", 
-      RowBox[{"a", "+", "b"}], "]"}], ",", 
-     RowBox[{"NumpyPrefix", "\[Rule]", " ", "\"\<numpy\>\""}]}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"Cos", "[", 
-      RowBox[{"{", 
-       RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], ",", 
-     RowBox[{"NumpyPrefix", "\[Rule]", " ", "\"\<numpy\>\""}]}], 
-    "]"}]}]}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020699758286*^9}, {3.817042046873148*^9, 
-  3.817042048134284*^9}, {3.834825479111014*^9, 3.834825486108267*^9}},
- CellLabel->"In[71]:=",ExpressionUUID->"f6527cd2-52e4-49a6-9b6c-bc9c98edc4bd"],
-
-Cell[BoxData["\<\"numpy.pi * numpy.cosh(a) * (1 / numpy.sin(b))\"\>"], \
-"Output",
- CellChangeTimes->{{3.834825430790345*^9, 3.834825457619651*^9}, 
-   3.834825494795306*^9, 3.834825655952808*^9, 3.846041872762762*^9, 
-   3.846042345931856*^9, 3.846408252478046*^9},
- CellLabel->"Out[71]=",ExpressionUUID->"45383448-7da3-4bb2-aa79-fa57c9eba20f"],
-
-Cell[BoxData["\<\"numpy.exp(a + b)\"\>"], "Output",
- CellChangeTimes->{{3.834825430790345*^9, 3.834825457619651*^9}, 
-   3.834825494795306*^9, 3.834825655952808*^9, 3.846041872762762*^9, 
-   3.846042345931856*^9, 3.846408252479697*^9},
- CellLabel->"Out[72]=",ExpressionUUID->"2bd16af2-3be7-4a2b-b41f-1c66aca38621"],
-
-Cell[BoxData["\<\"numpy.array([numpy.cos(1), numpy.cos(2), \
-numpy.cos(3)])\"\>"], "Output",
- CellChangeTimes->{{3.834825430790345*^9, 3.834825457619651*^9}, 
-   3.834825494795306*^9, 3.834825655952808*^9, 3.846041872762762*^9, 
-   3.846042345931856*^9, 3.846408252481016*^9},
- CellLabel->"Out[73]=",ExpressionUUID->"06fee358-9a64-4080-a1b6-347d5d7f63c8"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{
-   "Example", " ", "with", " ", "numpy", " ", "as", " ", 
-    "\"\<from numpy import *\>\""}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"\[Pi]", " ", 
-      RowBox[{
-       RowBox[{"Cosh", "[", "a", "]"}], "/", 
-       RowBox[{"Sin", "[", "b", "]"}]}]}], ",", 
-     RowBox[{"NumpyPrefix", "\[Rule]", "\"\<\>\""}]}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"Exp", "[", 
-      RowBox[{"a", "+", "b"}], "]"}], ",", 
-     RowBox[{"NumpyPrefix", "\[Rule]", "\"\<\>\""}]}], "]"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{"ToPython", "[", 
-    RowBox[{
-     RowBox[{"Cos", "[", 
-      RowBox[{"{", 
-       RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], ",", 
-     RowBox[{"NumpyPrefix", "\[Rule]", "\"\<\>\""}]}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020694983716*^9}, {3.846408271620933*^9, 
-  3.8464082821115227`*^9}},
- CellLabel->"In[83]:=",ExpressionUUID->"5515cb8d-3b4a-4f07-909f-e82f28173e96"],
-
-Cell[BoxData["\<\"pi * cosh(a) * (1 / sin(b))\"\>"], "Output",
- CellChangeTimes->{{3.8348254308298597`*^9, 3.8348254576304607`*^9}, 
-   3.834825494839604*^9, 3.834825655996907*^9, 3.846041872772156*^9, 
-   3.8460423459407063`*^9, {3.846408252488163*^9, 3.846408282512183*^9}},
- CellLabel->"Out[83]=",ExpressionUUID->"240ed9f5-031a-433b-b506-e4041a7c85e9"],
-
-Cell[BoxData["\<\"exp(a + b)\"\>"], "Output",
- CellChangeTimes->{{3.8348254308298597`*^9, 3.8348254576304607`*^9}, 
-   3.834825494839604*^9, 3.834825655996907*^9, 3.846041872772156*^9, 
-   3.8460423459407063`*^9, {3.846408252488163*^9, 3.8464082825143633`*^9}},
- CellLabel->"Out[84]=",ExpressionUUID->"2328c139-66f6-433b-9b3f-558e02b8de97"],
-
-Cell[BoxData["\<\"array([cos(1), cos(2), cos(3)])\"\>"], "Output",
- CellChangeTimes->{{3.8348254308298597`*^9, 3.8348254576304607`*^9}, 
-   3.834825494839604*^9, 3.834825655996907*^9, 3.846041872772156*^9, 
-   3.8460423459407063`*^9, {3.846408252488163*^9, 3.846408282516893*^9}},
- CellLabel->"Out[85]=",ExpressionUUID->"738a495d-78bf-4d91-84db-aa6df0d4f9c6"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", " ", 
-   RowBox[{"Special", " ", "functions"}], " ", "*)"}], "\[IndentingNewLine]", 
-  
-  RowBox[{"ToPython", "[", 
-   RowBox[{"SphericalHarmonicY", "[", 
-    RowBox[{"l", ",", "m", ",", "\[Theta]", ",", "\[Phi]"}], "]"}], 
-   "]"}]}]], "Input",
- CellChangeTimes->{{3.8171174664415627`*^9, 3.8171175150332823`*^9}},
- CellLabel->"In[77]:=",ExpressionUUID->"0e4529e0-9456-4a42-870d-172c1748c68e"],
-
-Cell[BoxData["\<\"special.sph_harm(m, l, (phi) % (2 * np.pi), (theta) % \
-np.pi)\"\>"], "Output",
- CellChangeTimes->{{3.8348254308381367`*^9, 3.8348254576675386`*^9}, 
-   3.8348254948487988`*^9, 3.834825656005947*^9, 3.846041872817704*^9, 
-   3.846042345983569*^9, 3.846408252528775*^9},
- CellLabel->"Out[77]=",ExpressionUUID->"4ae6d35d-df52-4700-92a8-95c90f0e39a4"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{"ToPython", "[", 
-  RowBox[{"Sqrt", "[", "a", "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.817120078799831*^9, 3.817120082942841*^9}},
- CellLabel->"In[78]:=",ExpressionUUID->"0ae939ea-d5e9-419b-999a-64601c326ce5"],
-
-Cell[BoxData["\<\"np.sqrt(a)\"\>"], "Output",
- CellChangeTimes->{{3.834825430844825*^9, 3.8348254576733294`*^9}, 
-   3.834825494889243*^9, 3.834825656045374*^9, 3.846041872824448*^9, 
-   3.84604234598946*^9, 3.846408252535535*^9},
- CellLabel->"Out[78]=",ExpressionUUID->"85a68d86-e2b6-4a71-9623-f36bf1d145f4"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{"ToPython", "[", 
-  RowBox[{"{", 
-   RowBox[{"1", ",", "2", ",", 
-    RowBox[{"a", "+", "b", "+", 
-     RowBox[{"Sin", "[", "x", "]"}]}]}], "}"}], "]"}]], "Input",
- CellChangeTimes->{{3.8171328786925697`*^9, 3.8171328909644003`*^9}},
- CellLabel->"In[79]:=",ExpressionUUID->"096db8ac-16bc-4502-968b-388523b12c99"],
-
-Cell[BoxData["\<\"np.array([1, 2, a + b + np.sin(x)])\"\>"], "Output",
- CellChangeTimes->{{3.834825430851001*^9, 3.834825457706586*^9}, 
-   3.8348254948948517`*^9, 3.83482565605092*^9, 3.846041872873*^9, 
-   3.846042346027454*^9, 3.846408252582428*^9},
- CellLabel->"Out[79]=",ExpressionUUID->"70a28131-2827-4521-9b2f-3564cb142e37"]
-}, Open  ]]
-},
-WindowSize->{808, 701},
-WindowMargins->{{Automatic, 150}, {Automatic, 131}},
-FrontEndVersion->"12.1 for Mac OS X x86 (64-bit) (March 13, 2020)",
-StyleDefinitions->"Default.nb",
-ExpressionUUID->"798b0806-392b-4800-9dba-1ecc8fa5714a"
+Notebook[
+  {
+    Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{RowBox[{"loads", " ", 
+      "the", " ", "package"}], " ", "-", " ", RowBox[{"after", " ", "installation"
+      }]}], "*)"}], "\[IndentingNewLine]", RowBox[{"Get", "@", RowBox[{"FileNameJoin",
+       "[", RowBox[{"{", RowBox[{RowBox[{"NotebookDirectory", "[", "]"}], ",",
+       "\"\<ToPython.wl\>\""}], "}"}], "]"}]}]}]], "Input", CellChangeTimes
+       -> {{3.70181767476367*^9, 3.701817694205203*^9}, {3.7018181976937943`*^9,
+       3.701818211998588*^9}, {3.817007877025469*^9, 3.81700790447239*^9}, 
+      {3.8172214865707483`*^9, 3.81722149743857*^9}}, CellLabel -> "In[47]:=",
+       ExpressionUUID -> "ee6242fe-5738-42d7-927d-12c3be9f45f8"]
+    ,
+    Cell[
+      CellGroupData[
+        {
+          Cell[BoxData[RowBox[{"?", "ToPython"}]], "Input", CellChangeTimes
+             -> {{3.70181815383568*^9, 3.7018181578773003`*^9}, 3.701818214459565*^9,
+             {3.817118303280854*^9, 3.817118304890544*^9}, {3.8171204416196833`*^9,
+             3.8171204422649813`*^9}, {3.846041124797001*^9, 3.846041134384152*^9
+            }}, CellLabel -> "In[48]:=", ExpressionUUID -> "e8858397-83ae-4bb9-9a33-1b677626ef0c"
+            ]
+          ,
+          Cell[BoxData[TemplateBox[{"StringForm", "string", "\"String expected at position StandardForm[Short[Shallow[HoldForm[1], {10, 50}], 5]] in StandardForm[Short[Shallow[HoldForm[StringForm[Private`s, Sequence @@ Private`PythonForm /@ {Private`args}]], {10, 50}], 5]].\"",
+             2, 48, 1, 27837000086921606047, "Local"}, "MessageTemplate"]], "Message",
+             "MSG", CellChangeTimes -> {{3.846041131173876*^9, 3.8460411348863487`*^9
+            }, 3.846041288298971*^9, 3.846041712287074*^9, {3.84604174243005*^9, 
+            3.846041755722417*^9}, 3.8460418725700493`*^9, 3.84604234575531*^9, 3.8464081244260674`*^9,
+             3.846408252278989*^9}, CellLabel -> "During evaluation of In[48]:=",
+             ExpressionUUID -> "8547ffc5-678a-4925-92f6-8ad83246e2a7"]
+          ,
+          Cell[
+            BoxData[
+              InterpretationBox[
+                StyleBox[FrameBox[DynamicModuleBox[{System`InformationDump`open$$
+                   = False, System`InformationDump`mouseOver$$ = False}, PaneSelectorBox[
+                  {True -> TagBox[GridBox[{{ItemBox[PaneBox[StyleBox["\<\" Symbol\"\>",
+                   "InformationTitleText", StripOnInput -> False, BaseStyle -> None], FrameMargins
+                   -> {{4, 0}, {-1, 1}}], BaseStyle -> "InformationTitleBackground", StripOnInput
+                   -> False], ItemBox["\<\"\"\>", BaseStyle -> "InformationTitleBackground",
+                   StripOnInput -> False]}, {ItemBox[PaneBox[StyleBox["\<\"ToPython[expression, NumpyPrefix->\\\"np\\\", Copy->False]\\n\\tconverts Mathematica expression to a Numpy compatible expression. Because Numpy can\\n\\tbe imported in several ways, you can specify the name of the numpy module using the\\n    NumpyPrefix option. The additional option Copy allows you to copy the result to the clipboard\"\>",
+                   "InformationUsageText", StripOnInput -> False, LineSpacing -> {1.5, 
+                  1.5, 3.}], FrameMargins -> {{10, 10}, {8, 10}}], BaseStyle -> "InformationUsageSubtitleBackground",
+                   StripOnInput -> False], ItemBox["\<\"\"\>", BaseStyle -> "InformationUsageSubtitleBackground",
+                   StripOnInput -> False]}, {PaneBox[GridBox[{{DynamicModuleBox[{System`InformationDump`open$$
+                   = {False, False, False, False, False, False, False, False, False, False,
+                   False, False}}, StyleBox[GridBox[{{TagBox[TooltipBox[StyleBox["\<\" Definitions\"\>",
+                   "InformationRowLabel", StripOnInput -> False], "\"Definitions\"", TooltipStyle
+                   -> "TextStyling"], Annotation[#, "Definitions", "Tooltip"]&], GridBox[
+                  {{RowBox[{RowBox[{"ToPython", "[", RowBox[{"Private`expression_", ",",
+                   RowBox[{"OptionsPattern", "[", "]"}]}], "]"}], ":=", RowBox[{"Module",
+                   "[", RowBox[{RowBox[{"{", RowBox[{RowBox[{"Private`numpyprefix", "=",
+                   RowBox[{"OptionValue", "[", "Private`NumpyPrefix", "]"}]}], ",", RowBox[
+                  {"Private`copy", "=", RowBox[{"OptionValue", "[", "Private`Copy", "]"
+                  }]}], ",", "Private`result", ",", "Private`greekrule", ",", "Private`format",
+                   ",", "Private`PythonForm", ",", "Private`np", ",", "Private`br", ",",
+                   "Private`brackets", ",", "Private`a", ",", "Private`b", ",", "Private`l",
+                   ",", "Private`m", ",", "Private`args"}], "}"}], ",", RowBox[{RowBox[
+                  {"If", "[", RowBox[{RowBox[{"Private`numpyprefix", "\[Equal]", "\<\"\"\>"
+                  }], ",", RowBox[{"Private`np", "=", "Private`numpyprefix"}], ",", RowBox[
+                  {"Private`np", "=", RowBox[{"Private`numpyprefix", "<>", "\<\".\"\>"}
+                  ]}]}], "]"}], ";", RowBox[{RowBox[{"Private`format", "[", RowBox[{"Private`pattern_String",
+                   ",", "Private`args__"}], "]"}], ":=", RowBox[{"Module", "[", RowBox[
+                  {RowBox[{"{", "Private`s", "}"}], ",", RowBox[{RowBox[{"Private`s", "=",
+                   RowBox[{"StringReplace", "[", RowBox[{"Private`pattern", ",", RowBox[
+                  {"\<\"numpy.\"\>", "\[Rule]", "Private`np"}]}], "]"}]}], ";", RowBox[
+                  {"ToString", "[", RowBox[{"StringForm", "[", RowBox[{"Private`s", ",",
+                   RowBox[{"Sequence", "@@", RowBox[{"Private`PythonForm", "/@", RowBox[
+                  {"{", "Private`args", "}"}]}]}]}], "]"}], "]"}]}]}], "]"}]}], ";", RowBox[
+                  {RowBox[{"Private`br", "[", "Private`a_", "]"}], ":=", RowBox[{"If", 
+                  "[", RowBox[{RowBox[{RowBox[{"AtomQ", "[", "Private`a", "]"}], "||", 
+                  RowBox[{"MemberQ", "[", RowBox[{"Private`singleFunctions", ",", RowBox[
+                  {"Head", "[", "Private`a", "]"}]}], "]"}]}], ",", "Private`a", ",", RowBox[
+                  {"Private`brackets", "[", "Private`a", "]"}]}], "]"}]}], ";", RowBox[
+                  {RowBox[{"Private`PythonForm", "[", RowBox[{"Private`brackets", "[", 
+                  "Private`a_", "]"}], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[
+                  {"\<\"(``)\"\>", ",", "Private`a"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"-", "Private`a_"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"-``\"\>", ",", RowBox[{"Private`br", "[", "Private`a",
+                   "]"}]}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[", SuperscriptBox[
+                  "Private`a_", RowBox[{"Rational", "[", RowBox[{"1", ",", "2"}], "]"}]
+                  ], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"numpy.sqrt(``)\"\>",
+                   ",", "Private`a"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", FractionBox["Private`a_", "Private`b_"], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"`` / ``\"\>", ",", RowBox[{"Private`br", "[", "Private`a",
+                   "]"}], ",", RowBox[{"Private`br", "[", "Private`b", "]"}]}], "]"}]}],
+                   ";", RowBox[{StyleBox[RowBox[{"ToPython", "::", "hasDerivative"}], "MessageName"
+                  ], "=", "\<\"Dervatives are not supported\"\>"}], ";", RowBox[{RowBox[
+                  {"Private`PythonForm", "[", RowBox[{"Derivative", "[", "___", "]"}], 
+                  "]"}], ":=", RowBox[{"(", RowBox[{RowBox[{"Message", "[", StyleBox[RowBox[
+                  {"ToPython", "::", "hasDerivative"}], "MessageName"], "]"}], ";", RowBox[
+                  {"Abort", "[", "]"}]}], ")"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"Rational", "[", RowBox[{"Private`a_", ",", "Private`b_"
+                  }], "]"}], "]"}], ":=", RowBox[{"ToString", "[", RowBox[{RowBox[{"N",
+                   "[", RowBox[{FractionBox["Private`a", "Private`b"], ",", "$MachinePrecision"
+                  }], "]"}], ",", "FortranForm"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", "Private`a_Rational", "]"}], ":=", RowBox[{"ToString", "[", RowBox[
+                  {RowBox[{"N", "[", RowBox[{"Private`a", ",", "$MachinePrecision"}], "]"
+                  }], ",", "FortranForm"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"Complex", "[", RowBox[{"Private`a_", ",", "Private`b_"
+                  }], "]"}], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"complex(``, ``)\"\>",
+                   ",", "Private`a", ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{
+                  "Private`PythonForm", "[", RowBox[{"Private`a_", " ", "Private`b__"}],
+                   "]"}], ":=", RowBox[{"Module", "[", RowBox[{RowBox[{"{", RowBox[{"Private`fs",
+                   ",", RowBox[{"Private`bl", "=", RowBox[{"{", "Private`b", "}"}]}]}],
+                   "}"}], ",", RowBox[{RowBox[{"Private`fs", "=", RowBox[{"StringRiffle",
+                   "[", RowBox[{RowBox[{"ConstantArray", "[", RowBox[{"\<\"``\"\>", ",",
+                   RowBox[{"1", "+", RowBox[{"Length", "[", "Private`bl", "]"}]}]}], "]"
+                  }], ",", "\<\" * \"\>"}], "]"}]}], ";", RowBox[{"Private`format", "[",
+                   RowBox[{"Private`fs", ",", RowBox[{"Private`br", "[", "Private`a", "]"
+                  }], ",", RowBox[{"Sequence", "@@", RowBox[{"Private`br", "/@", "Private`bl"
+                  }]}]}], "]"}]}]}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"Private`a_", "+", "Private`b_"}], "]"}], ":=", RowBox[
+                  {"Private`format", "[", RowBox[{"\<\"`` + ``\"\>", ",", "Private`a", 
+                  ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", SuperscriptBox["Private`a_", "Private`b_"], "]"}], ":=", RowBox[
+                  {"Private`format", "[", RowBox[{"\<\"`` ** ``\"\>", ",", RowBox[{"Private`br",
+                   "[", "Private`a", "]"}], ",", RowBox[{"Private`br", "[", "Private`b",
+                   "]"}]}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[
+                  {"Exp", "[", "Private`a_", "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"numpy.exp(``)\"\>", ",", "Private`a"}], "]"}]}], ";",
+                   RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"Max", "[", RowBox[
+                  {"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"numpy.maximum(`1`, `2`)\"\>", ",", "Private`a", ",",
+                   "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[",
+                   RowBox[{"Min", "[", RowBox[{"Private`a_", ",", "Private`b_"}], "]"}],
+                   "]"}], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"numpy.minimum(`1`, `2`)\"\>",
+                   ",", "Private`a", ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{
+                  "Private`PythonForm", "[", RowBox[{"Arg", "[", "Private`a_", "]"}], "]"
+                  }], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"numpy.angle(``)\"\>",
+                   ",", "Private`a"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"SphericalHarmonicY", "[", RowBox[{"Private`l_", ",", "Private`m_",
+                   ",", "Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{
+                  "Private`format", "[", RowBox[{"\<\"special.sph_harm(``, ``, (``) % (2 * numpy.pi), (``) % numpy.pi)\"\>",
+                   ",", "Private`m", ",", "Private`l", ",", "Private`b", ",", "Private`a"
+                  }], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{
+                  "Gamma", "[", "Private`a_", "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.gamma(``)\"\>", ",", "Private`a"}], "]"}]}
+                  ], ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"Gamma", "[",
+                   RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[
+                  {"Private`format", "[", RowBox[{"\<\"special.gamma(`1`) * special.gammaincc(`1`, `2`)\"\>",
+                   ",", "Private`a", ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{
+                  "Private`PythonForm", "[", RowBox[{"BesselI", "[", RowBox[{"0", ",", 
+                  "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[
+                  {"\<\"special.i0(``)\"\>", ",", "Private`b"}], "]"}]}], ";", RowBox[{
+                  RowBox[{"Private`PythonForm", "[", RowBox[{"BesselJ", "[", RowBox[{"0",
+                   ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format", "[",
+                   RowBox[{"\<\"special.j0(``)\"\>", ",", "Private`b"}], "]"}]}], ";", 
+                  RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselK", "[", RowBox[
+                  {"0", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.k0(``)\"\>", ",", "Private`b"}], "]"}]}], 
+                  ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselY", "[",
+                   RowBox[{"0", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.y0(``)\"\>", ",", "Private`b"}], "]"}]}], 
+                  ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselI", "[",
+                   RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.i1(``)\"\>", ",", "Private`b"}], "]"}]}], 
+                  ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselJ", "[",
+                   RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.j1(``)\"\>", ",", "Private`b"}], "]"}]}], 
+                  ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselK", "[",
+                   RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.k1(``)\"\>", ",", "Private`b"}], "]"}]}], 
+                  ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselY", "[",
+                   RowBox[{"1", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"special.y1(``)\"\>", ",", "Private`b"}], "]"}]}], 
+                  ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"BesselI", "[",
+                   RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[
+                  {"Private`format", "[", RowBox[{"\<\"special.iv(``, ``)\"\>", ",", "Private`a",
+                   ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"BesselJ", "[", RowBox[{"Private`a_", ",", "Private`b_"
+                  }], "]"}], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"special.jv(``, ``)\"\>",
+                   ",", "Private`a", ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{
+                  "Private`PythonForm", "[", RowBox[{"BesselK", "[", RowBox[{"Private`a_",
+                   ",", "Private`b_"}], "]"}], "]"}], ":=", RowBox[{"Private`format", "[",
+                   RowBox[{"\<\"special.kn(``, ``)\"\>", ",", "Private`a", ",", "Private`b"
+                  }], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{
+                  "BesselY", "[", RowBox[{"Private`a_", ",", "Private`b_"}], "]"}], "]"
+                  }], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"special.yn(``, ``)\"\>",
+                   ",", "Private`a", ",", "Private`b"}], "]"}]}], ";", RowBox[{RowBox[{
+                  "Private`PythonForm", "[", RowBox[{"Csc", "[", "Private`a_", "]"}], "]"
+                  }], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"1 / numpy.sin(``)\"\>",
+                   ",", "Private`a"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"Sec", "[", "Private`a_", "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"1 / numpy.cos(``)\"\>", ",", "Private`a"}], "]"}]}
+                  ], ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{"Cot", "[",
+                   "Private`a_", "]"}], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[
+                  {"\<\"1 / numpy.tan(``)\"\>", ",", "Private`a"}], "]"}]}], ";", RowBox[
+                  {RowBox[{"Private`PythonForm", "[", RowBox[{"Csch", "[", "Private`a_",
+                   "]"}], "]"}], ":=", RowBox[{"Private`format", "[", RowBox[{"\<\"1 / numpy.sinh(``)\"\>",
+                   ",", "Private`a"}], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"Sech", "[", "Private`a_", "]"}], "]"}], ":=", RowBox[{
+                  "Private`format", "[", RowBox[{"\<\"1 / numpy.cosh(``)\"\>", ",", "Private`a"
+                  }], "]"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[", RowBox[{
+                  "Coth", "[", "Private`a_", "]"}], "]"}], ":=", RowBox[{"Private`format",
+                   "[", RowBox[{"\<\"1 / numpy.tanh(``)\"\>", ",", "Private`a"}], "]"}]
+                  }], ";", RowBox[{RowBox[{"Private`PythonForm", "[", "Private`a_NumericArray",
+                   "]"}], ":=", RowBox[{"Private`np", "<>", "\<\"array(\"\>", "<>", RowBox[
+                  {"StringReplace", "[", RowBox[{RowBox[{"ToString", "[", RowBox[{"Normal",
+                   "[", "Private`a", "]"}], "]"}], ",", RowBox[{"{", RowBox[{RowBox[{"\<\"{\"\>",
+                   "\[Rule]", "\<\"[\"\>"}], ",", RowBox[{"\<\"}\"\>", "\[Rule]", "\<\"]\"\>"
+                  }]}], "}"}]}], "]"}], "<>", "\<\")\"\>"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"{", "Private`args__", "}"}], "]"}], ":=", RowBox[{"Private`np",
+                   "<>", "\<\"array([\"\>", "<>", RowBox[{"StringRiffle", "[", RowBox[{
+                  RowBox[{"Private`PythonForm", "/@", RowBox[{"{", "Private`args", "}"}
+                  ]}], ",", "\<\", \"\>"}], "]"}], "<>", "\<\"])\"\>"}]}], ";", RowBox[
+                  {RowBox[{"Private`PythonForm", "[", "\[Pi]", "]"}], "=", RowBox[{"Private`np",
+                   "<>", "\<\"pi\"\>"}]}], ";", RowBox[{RowBox[{"Private`PythonForm", "[",
+                   "\[ExponentialE]", "]"}], "=", RowBox[{"Private`np", "<>", "\<\"e\"\>"
+                  }]}], ";", RowBox[{"Private`greekrule", "=", RowBox[{"{", RowBox[{RowBox[
+                  {"\<\"\[Alpha]\"\>", "\[Rule]", "\<\"alpha\"\>"}], ",", RowBox[{"\<\"\[Beta]\"\>",
+                   "\[Rule]", "\<\"beta\"\>"}], ",", RowBox[{"\<\"\[Gamma]\"\>", "\[Rule]",
+                   "\<\"gamma\"\>"}], ",", RowBox[{"\<\"\[Delta]\"\>", "\[Rule]", "\<\"delta\"\>"
+                  }], ",", RowBox[{"\<\"\[CurlyEpsilon]\"\>", "\[Rule]", "\<\"curlyepsilon\"\>"
+                  }], ",", RowBox[{"\<\"\[Zeta]\"\>", "\[Rule]", "\<\"zeta\"\>"}], ",",
+                   RowBox[{"\<\"\[Eta]\"\>", "\[Rule]", "\<\"eta\"\>"}], ",", RowBox[{"\<\"\[Theta]\"\>",
+                   "\[Rule]", "\<\"theta\"\>"}], ",", RowBox[{"\<\"\[Iota]\"\>", "\[Rule]",
+                   "\<\"iota\"\>"}], ",", RowBox[{"\<\"\[Kappa]\"\>", "\[Rule]", "\<\"kappa\"\>"
+                  }], ",", RowBox[{"\<\"\[Lambda]\"\>", "\[Rule]", "\<\"lambda\"\>"}], 
+                  ",", RowBox[{"\<\"\[Mu]\"\>", "\[Rule]", "\<\"mu\"\>"}], ",", RowBox[
+                  {"\<\"\[Nu]\"\>", "\[Rule]", "\<\"nu\"\>"}], ",", RowBox[{"\<\"\[Xi]\"\>",
+                   "\[Rule]", "\<\"xi\"\>"}], ",", RowBox[{"\<\"\[Omicron]\"\>", "\[Rule]",
+                   "\<\"omicron\"\>"}], ",", RowBox[{"\<\"\[Pi]\"\>", "\[Rule]", "\<\"pi\"\>"
+                  }], ",", RowBox[{"\<\"\[Rho]\"\>", "\[Rule]", "\<\"rho\"\>"}], ",", RowBox[
+                  {"\<\"\[FinalSigma]\"\>", "\[Rule]", "\<\"finalsigma\"\>"}], ",", RowBox[
+                  {"\<\"\[Sigma]\"\>", "\[Rule]", "\<\"sigma\"\>"}], ",", RowBox[{"\<\"\[Tau]\"\>",
+                   "\[Rule]", "\<\"tau\"\>"}], ",", RowBox[{"\<\"\[Upsilon]\"\>", "\[Rule]",
+                   "\<\"upsilon\"\>"}], ",", RowBox[{"\<\"\[CurlyPhi]\"\>", "\[Rule]", 
+                  "\<\"curlyphi\"\>"}], ",", RowBox[{"\<\"\[Chi]\"\>", "\[Rule]", "\<\"chi\"\>"
+                  }], ",", RowBox[{"\<\"\[Phi]\"\>", "\[Rule]", "\<\"phi\"\>"}], ",", RowBox[
+                  {"\<\"\[Psi]\"\>", "\[Rule]", "\<\"psi\"\>"}], ",", RowBox[{"\<\"\[Omega]\"\>",
+                   "\[Rule]", "\<\"omega\"\>"}], ",", RowBox[{"\<\"\[CapitalAlpha]\"\>",
+                   "\[Rule]", "\<\"Alpha\"\>"}], ",", RowBox[{"\<\"\[CapitalBeta]\"\>",
+                   "\[Rule]", "\<\"Beta\"\>"}], ",", RowBox[{"\<\"\[CapitalGamma]\"\>",
+                   "\[Rule]", "\<\"Gamma\"\>"}], ",", RowBox[{"\<\"\[CapitalDelta]\"\>",
+                   "\[Rule]", "\<\"Delta\"\>"}], ",", RowBox[{"\<\"\[CapitalEpsilon]\"\>",
+                   "\[Rule]", "\<\"CurlyEpsilon\"\>"}], ",", RowBox[{"\<\"\[CapitalZeta]\"\>",
+                   "\[Rule]", "\<\"Zeta\"\>"}], ",", RowBox[{"\<\"\[CapitalEta]\"\>", "\[Rule]",
+                   "\<\"Eta\"\>"}], ",", RowBox[{"\<\"\[CapitalTheta]\"\>", "\[Rule]", 
+                  "\<\"Theta\"\>"}], ",", RowBox[{"\<\"\[CapitalIota]\"\>", "\[Rule]", 
+                  "\<\"Iota\"\>"}], ",", RowBox[{"\<\"\[CapitalKappa]\"\>", "\[Rule]", 
+                  "\<\"Kappa\"\>"}], ",", RowBox[{"\<\"\[CapitalLambda]\"\>", "\[Rule]",
+                   "\<\"Lambda\"\>"}], ",", RowBox[{"\<\"\[CapitalMu]\"\>", "\[Rule]", 
+                  "\<\"Mu\"\>"}], ",", RowBox[{"\<\"\[CapitalNu]\"\>", "\[Rule]", "\<\"Nu\"\>"
+                  }], ",", RowBox[{"\<\"\[CapitalXi]\"\>", "\[Rule]", "\<\"Xi\"\>"}], ",",
+                   RowBox[{"\<\"\[CapitalOmicron]\"\>", "\[Rule]", "\<\"Omicron\"\>"}],
+                   ",", RowBox[{"\<\"\[CapitalPi]\"\>", "\[Rule]", "\<\"Pi\"\>"}], ",",
+                   RowBox[{"\<\"\[CapitalRho]\"\>", "\[Rule]", "\<\"Rho\"\>"}], ",", RowBox[
+                  {"\<\"\[CapitalSigma]\"\>", "\[Rule]", "\<\"Sigma\"\>"}], ",", RowBox[
+                  {"\<\"\[CapitalTau]\"\>", "\[Rule]", "\<\"Tau\"\>"}], ",", RowBox[{"\<\"\[CapitalUpsilon]\"\>",
+                   "\[Rule]", "\<\"Upsilon\"\>"}], ",", RowBox[{"\<\"\[CapitalPhi]\"\>",
+                   "\[Rule]", "\<\"CurlyPhi\"\>"}], ",", RowBox[{"\<\"\[CapitalChi]\"\>",
+                   "\[Rule]", "\<\"Chi\"\>"}], ",", RowBox[{"\<\"\[CapitalPsi]\"\>", "\[Rule]",
+                   "\<\"Psi\"\>"}], ",", RowBox[{"\<\"\[CapitalOmega]\"\>", "\[Rule]", 
+                  "\<\"Omega\"\>"}]}], "}"}]}], ";", RowBox[{RowBox[{"Private`PythonForm",
+                   "[", RowBox[{"Private`h_", "[", "Private`args__", "]"}], "]"}], ":=",
+                   RowBox[{"Private`np", "<>", RowBox[{"ToLowerCase", "[", RowBox[{"Private`PythonForm",
+                   "[", "Private`h", "]"}], "]"}], "<>", "\<\"(\"\>", "<>", RowBox[{"Private`PythonForm",
+                   "[", "Private`args", "]"}], "<>", "\<\")\"\>"}]}], ";", RowBox[{RowBox[
+                  {"Private`PythonForm", "[", "Private`allOther_", "]"}], ":=", RowBox[
+                  {"StringReplace", "[", RowBox[{RowBox[{"ToString", "[", RowBox[{"Private`allOther",
+                   ",", "FortranForm"}], "]"}], ",", "Private`greekrule"}], "]"}]}], ";",
+                   RowBox[{"Private`result", "=", RowBox[{"StringReplace", "[", RowBox[
+                  {RowBox[{"Private`PythonForm", "[", "Private`expression", "]"}], ",",
+                   "Private`greekrule"}], "]"}]}], ";", RowBox[{"If", "[", RowBox[{"Private`copy",
+                   ",", RowBox[{"CopyToClipboard", "[", "Private`result", "]"}]}], "]"}
+                  ], ";", "Private`result"}]}], "]"}]}]}}, DefaultBaseStyle -> "Column",
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, GridBoxItemSize -> {"Columns"
+                   -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, {TagBox[TooltipBox[StyleBox[
+                  "\<\" Options\"\>", "InformationRowLabel", StripOnInput -> False], "\"Options\"",
+                   TooltipStyle -> "TextStyling"], Annotation[#, "Options", "Tooltip"]&
+                  ], RowBox[{"{", RowBox[{RowBox[{"Private`NumpyPrefix", "\[Rule]", "\<\"np\"\>"
+                  }], ",", RowBox[{"Private`Copy", "\[Rule]", "False"}]}], "}"}]}, {TagBox[
+                  TooltipBox[StyleBox["\<\" Full Name\"\>", "InformationRowLabel", StripOnInput
+                   -> False], "\"FullName\"", TooltipStyle -> "TextStyling"], Annotation[
+                  #, "FullName", "Tooltip"]&], "\<\"ToPython`ToPython\"\>"}}, AutoDelete
+                   -> False, GridBoxAlignment -> {"Columns" -> {Right, Left}}, GridBoxDividers
+                   -> None, GridBoxItemSize -> {"Columns" -> {Automatic, Automatic}}, GridBoxSpacings
+                   -> {"Columns" -> {Offset[0.27999999999999997`], {Offset[0.5599999999999999
+                  ]}, Offset[0.27999999999999997`]}, "Rows" -> {Offset[0.2], {Offset[0.8
+                  ]}, Offset[0.2]}}], "DialogStyle", StripOnInput -> False], DynamicModuleValues
+                   :> {}]}}, DefaultBaseStyle -> "Column", GridBoxAlignment -> {"Columns"
+                   -> {{Left}}}, GridBoxDividers -> {"Columns" -> {{False}}, "Rows" -> 
+                  {{False}}}, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows" ->
+                   {{Automatic}}}, GridBoxSpacings -> {"Columns" -> {Offset[0.27999999999999997`
+                  ], {Offset[0.5599999999999999]}, Offset[0.27999999999999997`]}, "Rows"
+                   -> {Offset[0.2], {Offset[3.6]}, Offset[0.2]}}], FrameMargins -> 6], 
+                  ""}, {ItemBox[TagBox[ButtonBox[PaneSelectorBox[{False -> DynamicBox[FEPrivate`FrontEndResource[
+                  "FEBitmaps", "UpPointerOpener"]], True -> DynamicBox[FEPrivate`FrontEndResource[
+                  "FEBitmaps", "UpPointerOpenerHot"]]}, Dynamic[System`InformationDump`mouseOver$$
+                  ]], Alignment -> Left, Appearance -> {"Default" -> None}, ButtonFunction
+                   :> FEPrivate`Set[System`InformationDump`open$$, False], Evaluator ->
+                   Automatic, FrameMargins -> {{9, 0}, {0, 0}}, ImageMargins -> 0, ImageSize
+                   -> Full, Method -> "Preemptive"], EventHandlerTag[{"MouseEntered" :>
+                   FEPrivate`Set[System`InformationDump`mouseOver$$, True], "MouseExited"
+                   :> FEPrivate`Set[System`InformationDump`mouseOver$$, False], Method 
+                  -> "Preemptive", PassEventsDown -> Automatic, PassEventsUp -> True}]],
+                   BaseStyle -> "InformationTitleBackground", StripOnInput -> False], "\[SpanFromLeft]"
+                  }}, AutoDelete -> False, FrameStyle -> Directive[GrayLevel[0.8], Thickness[
+                  Tiny]], GridBoxAlignment -> {"Columns" -> {Left, Right}, "Rows" -> {{
+                  Center}}}, GridBoxDividers -> {"Columns" -> {{None}}, "Rows" -> {False,
+                   {True}, False}}, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows"
+                   -> {{Automatic}}}], "Grid"], False -> TagBox[GridBox[{{ItemBox[PaneBox[
+                  StyleBox["\<\" Symbol\"\>", "InformationTitleText", StripOnInput -> False
+                  ], FrameMargins -> {{4, 0}, {-1, 1}}], BaseStyle -> "InformationTitleBackground",
+                   StripOnInput -> False], ItemBox["\<\"\"\>", BaseStyle -> "InformationTitleBackground",
+                   StripOnInput -> False]}, {ItemBox[PaneBox[StyleBox["\<\"ToPython[expression, NumpyPrefix->\\\"np\\\", Copy->False]\\n\\tconverts Mathematica expression to a Numpy compatible expression. Because Numpy can\\n\\tbe imported in several ways, you can specify the name of the numpy module using the\\n    NumpyPrefix option. The additional option Copy allows you to copy the result to the clipboard\"\>",
+                   "InformationUsageText", StripOnInput -> False, LineSpacing -> {1.5, 
+                  1.5, 3.}], FrameMargins -> {{10, 10}, {8, 10}}], BaseStyle -> "InformationUsageSubtitleBackground",
+                   StripOnInput -> False], ItemBox["\<\"\"\>", BaseStyle -> "InformationUsageSubtitleBackground",
+                   StripOnInput -> False]}, {ItemBox[TagBox[ButtonBox[PaneSelectorBox[{
+                  False -> DynamicBox[FEPrivate`FrontEndResource["FEBitmaps", "DownPointerOpener"
+                  ], ImageSizeCache -> {10., {2., 8.}}], True -> DynamicBox[FEPrivate`FrontEndResource[
+                  "FEBitmaps", "DownPointerOpenerHot"], ImageSizeCache -> {10., {2., 8.
+                  }}]}, Dynamic[System`InformationDump`mouseOver$$]], Alignment -> Left,
+                   Appearance -> {"Default" -> None}, ButtonFunction :> FEPrivate`Set[System`InformationDump`open$$,
+                   True], Evaluator -> Automatic, FrameMargins -> {{9, 0}, {0, 0}}, ImageMargins
+                   -> 0, ImageSize -> Full, Method -> "Preemptive"], EventHandlerTag[{"MouseEntered"
+                   :> FEPrivate`Set[System`InformationDump`mouseOver$$, True], "MouseExited"
+                   :> FEPrivate`Set[System`InformationDump`mouseOver$$, False], Method 
+                  -> "Preemptive", PassEventsDown -> Automatic, PassEventsUp -> True}]],
+                   BaseStyle -> "InformationTitleBackground", StripOnInput -> False], "\[SpanFromLeft]"
+                  }}, AutoDelete -> False, FrameStyle -> Directive[GrayLevel[0.8], Thickness[
+                  Tiny]], GridBoxAlignment -> {"Columns" -> {Left, Right}, "Rows" -> {{
+                  Center}}}, GridBoxDividers -> {"Columns" -> {{None}}, "Rows" -> {False,
+                   {True}, False}}, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows"
+                   -> {{Automatic}}}], "Grid"]}, Dynamic[System`InformationDump`open$$],
+                   BaselinePosition -> Baseline, FrameMargins -> 0, ImageSize -> Automatic
+                  ], DynamicModuleValues :> {}], BaseStyle -> "InformationGridFrame", StripOnInput
+                   -> False], "InformationGridPlain", StripOnInput -> False]
+                ,
+                InformationData[
+                  Association[
+                    "ObjectType" -> "Symbol"
+                    ,
+                    "Usage" -> "ToPython[expression, NumpyPrefix->\"np\", Copy->False]\n\tconverts Mathematica expression to a Numpy compatible expression. Because Numpy can\n\tbe imported in several ways, you can specify the name of the numpy module using the\n    NumpyPrefix option. The additional option Copy allows you to copy the result to the clipboard"
+                      
+                    ,
+                    "Documentation" -> None
+                    ,
+                    "OwnValues" -> None
+                    ,
+                    "UpValues" -> None
+                    ,
+                    "DownValues" ->
+                      Information`InformationValueForm[
+                        DownValues
+                        ,
+                        ToPython`ToPython
+                        ,
+                        {
+                          ToPython`ToPython[Pattern[Private`expression,
+                             Blank[]], OptionsPattern[]] :>
+                            Module[{Private`numpyprefix = OptionValue[
+                              Private`NumpyPrefix], Private`copy = OptionValue[Private`Copy], Private`result,
+                               Private`greekrule, Private`format, Private`PythonForm, Private`np, Private`br,
+                               Private`brackets, Private`a, Private`b, Private`l, Private`m, Private`args
+                              },
+                              If[Private`numpyprefix == "",
+                                Private`np = Private`numpyprefix
+                                ,
+                                Private`np = StringJoin[Private`numpyprefix,
+                                   "."]
+                              ];
+                              Private`format[Pattern[Private`pattern,
+                                 Blank[String]], Pattern[Private`args, BlankSequence[]]] :=
+                                Module[{Private`s},
+                                  Private`s = StringReplace[Private`pattern,
+                                     "numpy." -> Private`np];
+                                  ToString[StringForm[Private`s, Apply[
+                                    Sequence, Map[Private`PythonForm, {Private`args}]]]]
+                                ];
+                              Private`br[Pattern[Private`a, Blank[]]]
+                                 :=
+                                If[Or[AtomQ[Private`a], MemberQ[Private`singleFunctions,
+                                   Head[Private`a]]],
+                                  Private`a
+                                  ,
+                                  Private`brackets[Private`a]
+                                ];
+                              Private`PythonForm[Private`brackets[Pattern[
+                                Private`a, Blank[]]]] := Private`format["(``)", Private`a];
+                              Private`PythonForm[-Pattern[Private`a, 
+                                Blank[]]] := Private`format["-``", Private`br[Private`a]];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                ]] ^ Rational[1, 2]] := Private`format["numpy.sqrt(``)", Private`a];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                ]] / Pattern[Private`b, Blank[]]] := Private`format["`` / ``", Private`br[
+                                Private`a], Private`br[Private`b]];
+                              MessageName[ToPython`ToPython, "hasDerivative"
+                                ] = "Dervatives are not supported";
+                              Private`PythonForm[Derivative[BlankNullSequence[
+                                ]]] :=
+                                (
+                                  Message[MessageName[ToPython`ToPython,
+                                     "hasDerivative"]];
+                                  Abort[]
+                                );
+                              Private`PythonForm[Rational[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := ToString[N[Private`a / Private`b,
+                                 $MachinePrecision], FortranForm];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                Rational]]] := ToString[N[Private`a, $MachinePrecision], FortranForm]
+                                ;
+                              Private`PythonForm[Complex[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["complex(``, ``)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                ]] Pattern[Private`b, BlankSequence[]]] :=
+                                Module[{Private`fs, Private`bl = {Private`b
+                                  }},
+                                  Private`fs = StringRiffle[ConstantArray[
+                                    "``", 1 + Length[Private`bl]], " * "];
+                                  Private`format[Private`fs, Private`br[
+                                    Private`a], Apply[Sequence, Map[Private`br, Private`bl]]]
+                                ];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                ]] + Pattern[Private`b, Blank[]]] := Private`format["`` + ``", Private`a,
+                                 Private`b];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                ]] ^ Pattern[Private`b, Blank[]]] := Private`format["`` ** ``", Private`br[
+                                Private`a], Private`br[Private`b]];
+                              Private`PythonForm[Exp[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["numpy.exp(``)", Private`a];
+                              Private`PythonForm[Max[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["numpy.maximum(`1`, `2`)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[Min[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["numpy.minimum(`1`, `2`)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[Arg[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["numpy.angle(``)", Private`a];
+                              Private`PythonForm[SphericalHarmonicY[Pattern[
+                                Private`l, Blank[]], Pattern[Private`m, Blank[]], Pattern[Private`a, 
+                                Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["special.sph_harm(``, ``, (``) % (2 * numpy.pi), (``) % numpy.pi)",
+                                 Private`m, Private`l, Private`b, Private`a];
+                              Private`PythonForm[Gamma[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["special.gamma(``)", Private`a];
+                              Private`PythonForm[Gamma[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["special.gamma(`1`) * special.gammaincc(`1`, `2`)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[BesselI[0, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.i0(``)", Private`b];
+                              Private`PythonForm[BesselJ[0, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.j0(``)", Private`b];
+                              Private`PythonForm[BesselK[0, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.k0(``)", Private`b];
+                              Private`PythonForm[BesselY[0, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.y0(``)", Private`b];
+                              Private`PythonForm[BesselI[1, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.i1(``)", Private`b];
+                              Private`PythonForm[BesselJ[1, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.j1(``)", Private`b];
+                              Private`PythonForm[BesselK[1, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.k1(``)", Private`b];
+                              Private`PythonForm[BesselY[1, Pattern[Private`b,
+                                 Blank[]]]] := Private`format["special.y1(``)", Private`b];
+                              Private`PythonForm[BesselI[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["special.iv(``, ``)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[BesselJ[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["special.jv(``, ``)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[BesselK[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["special.kn(``, ``)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[BesselY[Pattern[Private`a,
+                                 Blank[]], Pattern[Private`b, Blank[]]]] := Private`format["special.yn(``, ``)",
+                                 Private`a, Private`b];
+                              Private`PythonForm[Csc[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["1 / numpy.sin(``)", Private`a];
+                              Private`PythonForm[Sec[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["1 / numpy.cos(``)", Private`a];
+                              Private`PythonForm[Cot[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["1 / numpy.tan(``)", Private`a];
+                              Private`PythonForm[Csch[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["1 / numpy.sinh(``)", Private`a];
+                              Private`PythonForm[Sech[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["1 / numpy.cosh(``)", Private`a];
+                              Private`PythonForm[Coth[Pattern[Private`a,
+                                 Blank[]]]] := Private`format["1 / numpy.tanh(``)", Private`a];
+                              Private`PythonForm[Pattern[Private`a, Blank[
+                                NumericArray]]] := StringJoin[Private`np, "array(", StringReplace[ToString[
+                                Normal[Private`a]], {"{" -> "[", "}" -> "]"}], ")"];
+                              Private`PythonForm[{Pattern[Private`args,
+                                 BlankSequence[]]}] := StringJoin[Private`np, "array([", StringRiffle[
+                                Map[Private`PythonForm, {Private`args}], ", "], "])"];
+                              Private`PythonForm[Pi] = StringJoin[Private`np,
+                                 "pi"];
+                              Private`PythonForm[E] = StringJoin[Private`np,
+                                 "e"];
+                              Private`greekrule = {"\[Alpha]" -> "alpha",
+                                 "\[Beta]" -> "beta", "\[Gamma]" -> "gamma", "\[Delta]" -> "delta", "\[CurlyEpsilon]"
+                                 -> "curlyepsilon", "\[Zeta]" -> "zeta", "\[Eta]" -> "eta", "\[Theta]"
+                                 -> "theta", "\[Iota]" -> "iota", "\[Kappa]" -> "kappa", "\[Lambda]" 
+                                -> "lambda", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
+                                 -> "omicron", "\[Pi]" -> "pi", "\[Rho]" -> "rho", "\[FinalSigma]" ->
+                                 "finalsigma", "\[Sigma]" -> "sigma", "\[Tau]" -> "tau", "\[Upsilon]"
+                                 -> "upsilon", "\[CurlyPhi]" -> "curlyphi", "\[Chi]" -> "chi", "\[Phi]"
+                                 -> "phi", "\[Psi]" -> "psi", "\[Omega]" -> "omega", "\[CapitalAlpha]"
+                                 -> "Alpha", "\[CapitalBeta]" -> "Beta", "\[CapitalGamma]" -> "Gamma",
+                                 "\[CapitalDelta]" -> "Delta", "\[CapitalEpsilon]" -> "CurlyEpsilon",
+                                 "\[CapitalZeta]" -> "Zeta", "\[CapitalEta]" -> "Eta", "\[CapitalTheta]"
+                                 -> "Theta", "\[CapitalIota]" -> "Iota", "\[CapitalKappa]" -> "Kappa",
+                                 "\[CapitalLambda]" -> "Lambda", "\[CapitalMu]" -> "Mu", "\[CapitalNu]"
+                                 -> "Nu", "\[CapitalXi]" -> "Xi", "\[CapitalOmicron]" -> "Omicron", "\[CapitalPi]"
+                                 -> "Pi", "\[CapitalRho]" -> "Rho", "\[CapitalSigma]" -> "Sigma", "\[CapitalTau]"
+                                 -> "Tau", "\[CapitalUpsilon]" -> "Upsilon", "\[CapitalPhi]" -> "CurlyPhi",
+                                 "\[CapitalChi]" -> "Chi", "\[CapitalPsi]" -> "Psi", "\[CapitalOmega]"
+                                 -> "Omega"};
+                              Private`PythonForm[Pattern[Private`h, Blank[
+                                ]][Pattern[Private`args, BlankSequence[]]]] := StringJoin[Private`np,
+                                 ToLowerCase[Private`PythonForm[Private`h]], "(", Private`PythonForm[
+                                Private`args], ")"];
+                              Private`PythonForm[Pattern[Private`allOther,
+                                 Blank[]]] := StringReplace[ToString[Private`allOther, FortranForm], 
+                                Private`greekrule];
+                              Private`result = StringReplace[Private`PythonForm[
+                                Private`expression], Private`greekrule];
+                              If[Private`copy,
+                                CopyToClipboard[Private`result]
+                              ];
+                              Private`result
+                            ]
+                        }
+                      ]
+                    ,
+                    "SubValues" -> None
+                    ,
+                    "DefaultValues" -> None
+                    ,
+                    "NValues" -> None
+                    ,
+                    "FormatValues" -> None
+                    ,
+                    "Options" -> {Private`NumpyPrefix -> "np", Private`Copy
+                       -> False}
+                    ,
+                    "Attributes" -> {}
+                    ,
+                    "FullName" -> "ToPython`ToPython"
+                  ]
+                  ,
+                  False
+                ]
+              ]
+            ]
+            ,
+            "Output"
+            ,
+            CellChangeTimes -> {{3.846041131188478*^9, 3.846041134941896*^9
+              }, 3.846041288348984*^9, 3.846041712356203*^9, {3.846041742478557*^9,
+               3.846041755771311*^9}, 3.846041872618247*^9, 3.8460423457875566`*^9,
+               3.846408124469769*^9, 3.8464082522938833`*^9}
+            ,
+            CellLabel -> "Out[48]="
+            ,
+            ExpressionUUID -> "42c28b92-2b81-493e-bb74-e25330a1fff5"
+          ]
+        }
+        ,
+        Open
+      ]
+    ]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", " ", "Numbers",
+       " ", "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ToPython", "[",
+       RowBox[{"1", "/", "2"}], "]"}], "\[IndentingNewLine]", RowBox[{"ToPython",
+       "[", RowBox[{"1", "/", "3"}], "]"}]}]}]], "Input", CellChangeTimes ->
+       {{3.846041020933352*^9, 3.8460410297347317`*^9}, {3.846041760995372*^9,
+       3.846041764297275*^9}, {3.846041864881761*^9, 3.846041865835989*^9}},
+       CellLabel -> "In[50]:=", ExpressionUUID -> "d17288e2-6b59-4b37-b3ab-c96969989f11"
+      ], Cell[BoxData["\<\"0.5\"\>"], "Output", CellChangeTimes -> {{3.846041025718354*^9,
+       3.8460410689851227`*^9}, 3.846041161606009*^9, 3.846041713588273*^9,
+       {3.8460417559319*^9, 3.846041768151883*^9}, 3.846041872624201*^9, 3.846042345795823*^9,
+       3.846408252327827*^9}, CellLabel -> "Out[50]=", ExpressionUUID -> "a735febf-e560-43bd-bd6d-f914d64a4827"
+      ], Cell[BoxData["\<\"0.3333333333333333\"\>"], "Output", CellChangeTimes
+       -> {{3.846041025718354*^9, 3.8460410689851227`*^9}, 3.846041161606009*^9,
+       3.846041713588273*^9, {3.8460417559319*^9, 3.846041768151883*^9}, 3.846041872624201*^9,
+       3.846042345795823*^9, 3.846408252329979*^9}, CellLabel -> "Out[51]=",
+       ExpressionUUID -> "acd027db-6e0c-4cf4-b716-fb0f2df127e2"]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{"Expression",
+       " ", "examples"}], "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ToPython",
+       "[", RowBox[{"a", "+", "b"}], "]"}], "\[IndentingNewLine]", RowBox[{
+      "ToPython", "[", RowBox[{"a", "*", "b", "*", "c"}], "]"}], "\[IndentingNewLine]",
+       RowBox[{"ToPython", "[", RowBox[{"a", "/", "b"}], "]"}], "\[IndentingNewLine]",
+       RowBox[{"ToPython", "[", RowBox[{RowBox[{"(", RowBox[{"a", "+", "b"}
+      ], ")"}], "/", RowBox[{"(", RowBox[{"d", "+", "e", "+", "g"}], ")"}]}
+      ], "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[", RowBox[{RowBox[
+      {"(", RowBox[{"a", "+", "b"}], ")"}], "^", RowBox[{"(", RowBox[{"d", 
+      "+", "e", "+", "g"}], ")"}]}], "]"}], "\[IndentingNewLine]", RowBox[{
+      "ToPython", "[", RowBox[{"Exp", "[", RowBox[{"a", "+", "b"}], "]"}], 
+      "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[", RowBox[{RowBox[
+      {"Sin", "[", RowBox[{"(", RowBox[{"a", "+", "b"}], ")"}], "]"}], "/",
+       RowBox[{"Cos", "[", RowBox[{"d", "+", "e"}], "]"}]}], "]"}], "\[IndentingNewLine]",
+       RowBox[{"ToPython", "[", RowBox[{RowBox[{"Sin", "[", RowBox[{"(", RowBox[
+      {"a", "+", "b"}], ")"}], "]"}], "/", RowBox[{"Tanh", "[", RowBox[{"d",
+       "+", "e"}], "]"}]}], "]"}], "\[IndentingNewLine]", RowBox[{"ToPython",
+       "[", RowBox[{"\[Pi]", " ", RowBox[{"Cosh", "[", "a", "]"}]}], "]"}],
+       "\[IndentingNewLine]", RowBox[{"ToPython", "[", RowBox[{"Log10", "[",
+       "x", "]"}], "]"}]}]}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9
+      }, {3.82438092026691*^9, 3.824380924710678*^9}, {3.824381208382967*^9,
+       3.824381214615004*^9}}, CellLabel -> "In[52]:=", ExpressionUUID -> "740923fd-dd9e-45ca-b781-36fcddb044a7"
+      ], Cell[BoxData["\<\"a + b\"\>"], "Output", CellChangeTimes -> {3.834824967993429*^9,
+       {3.8348250027856007`*^9, 3.834825025761455*^9}, 3.834825082517449*^9,
+       {3.834825113694745*^9, 3.834825131170567*^9}, 3.834825254557303*^9, 
+      3.834825365719318*^9, {3.8348254306713133`*^9, 3.834825457504114*^9},
+       3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9, 3.8460410406669703`*^9
+      }, 3.8460418726579113`*^9, 3.846042345821651*^9, 3.846408252358556*^9
+      }, CellLabel -> "Out[52]=", ExpressionUUID -> "88214388-71e3-462b-a5be-66420571aab7"
+      ], Cell[BoxData["\<\"a * b * c\"\>"], "Output", CellChangeTimes -> {3.834824967993429*^9,
+       {3.8348250027856007`*^9, 3.834825025761455*^9}, 3.834825082517449*^9,
+       {3.834825113694745*^9, 3.834825131170567*^9}, 3.834825254557303*^9, 
+      3.834825365719318*^9, {3.8348254306713133`*^9, 3.834825457504114*^9},
+       3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9, 3.8460410406669703`*^9
+      }, 3.8460418726579113`*^9, 3.846042345821651*^9, 3.846408252359899*^9
+      }, CellLabel -> "Out[53]=", ExpressionUUID -> "0023fa9a-51c8-4c11-b552-d32e67f3707f"
+      ], Cell[BoxData["\<\"a / b\"\>"], "Output", CellChangeTimes -> {3.834824967993429*^9,
+       {3.8348250027856007`*^9, 3.834825025761455*^9}, 3.834825082517449*^9,
+       {3.834825113694745*^9, 3.834825131170567*^9}, 3.834825254557303*^9, 
+      3.834825365719318*^9, {3.8348254306713133`*^9, 3.834825457504114*^9},
+       3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9, 3.8460410406669703`*^9
+      }, 3.8460418726579113`*^9, 3.846042345821651*^9, 3.8464082523613157`*^9
+      }, CellLabel -> "Out[54]=", ExpressionUUID -> "4273074a-af87-41ce-9cc6-ae203b991c32"
+      ], Cell[BoxData["\<\"(a + b) / (d + e + g)\"\>"], "Output", CellChangeTimes
+       -> {3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9
+      }, 3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9},
+       3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.846408252362858*^9}, CellLabel -> "Out[55]=", ExpressionUUID -> "bb9155fa-3227-43c3-a10a-f5d16b7cd372"
+      ], Cell[BoxData["\<\"(a + b) ** (d + e + g)\"\>"], "Output", CellChangeTimes
+       -> {3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9
+      }, 3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9},
+       3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.846408252364133*^9}, CellLabel -> "Out[56]=", ExpressionUUID -> "d7158797-1d4f-401d-bb64-c29b2496c672"
+      ], Cell[BoxData["\<\"np.exp(a + b)\"\>"], "Output", CellChangeTimes ->
+       {3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9
+      }, 3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9},
+       3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.84640825236545*^9}, CellLabel -> "Out[57]=", ExpressionUUID -> "e81953d6-e02b-4b0e-b543-bad8760a8b3b"
+      ], Cell[BoxData["\<\"(1 / np.cos(d + e)) * np.sin(a + b)\"\>"], "Output",
+       CellChangeTimes -> {3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9
+      }, 3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9},
+       3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.846408252366715*^9}, CellLabel -> "Out[58]=", ExpressionUUID -> "9a3c9c1d-3be9-4fb8-9a18-14e65e057788"
+      ], Cell[BoxData["\<\"(1 / np.tanh(d + e)) * np.sin(a + b)\"\>"], "Output",
+       CellChangeTimes -> {3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9
+      }, 3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9},
+       3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.846408252368518*^9}, CellLabel -> "Out[59]=", ExpressionUUID -> "e6d1f67c-7b2c-46c4-b5c9-122bbd12864b"
+      ], Cell[BoxData["\<\"np.pi * np.cosh(a)\"\>"], "Output", CellChangeTimes
+       -> {3.834824967993429*^9, {3.8348250027856007`*^9, 3.834825025761455*^9
+      }, 3.834825082517449*^9, {3.834825113694745*^9, 3.834825131170567*^9},
+       3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.8464082523698797`*^9}, CellLabel -> "Out[60]=", ExpressionUUID -> 
+      "f275590b-eaf0-4e44-b675-c92fb2ebc858"], Cell[BoxData["\<\"np.log(x) / np.log(10)\"\>"
+      ], "Output", CellChangeTimes -> {3.834824967993429*^9, {3.8348250027856007`*^9,
+       3.834825025761455*^9}, 3.834825082517449*^9, {3.834825113694745*^9, 
+      3.834825131170567*^9}, 3.834825254557303*^9, 3.834825365719318*^9, {3.8348254306713133`*^9,
+       3.834825457504114*^9}, 3.834825494671575*^9, 3.83482565583664*^9, {3.84604101911229*^9,
+       3.8460410406669703`*^9}, 3.8460418726579113`*^9, 3.846042345821651*^9,
+       3.846408252371305*^9}, CellLabel -> "Out[61]=", ExpressionUUID -> "caf70baa-78be-4c50-8a77-f181a689e36f"
+      ]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{"Expression",
+       " ", "with", " ", "greek", " ", "letters"}], "*)"}], "\[IndentingNewLine]",
+       RowBox[{"ToPython", "[", RowBox[{"Sin", "[", RowBox[{"\[Alpha]", "+",
+       "\[Beta]"}], "]"}], "]"}]}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.817020691587697*^9, 3.817020708510957*^9},
+       3.817041875624913*^9}, CellLabel -> "In[62]:=", ExpressionUUID -> "d695df00-d1d2-4318-b649-f671d424864e"
+      ], Cell[BoxData["\<\"np.sin(alpha + beta)\"\>"], "Output", CellChangeTimes
+       -> {{3.834825430723674*^9, 3.834825457528077*^9}, 3.8348254947234497`*^9,
+       3.8348256558938103`*^9, 3.8460418726745653`*^9, 3.846042345838647*^9,
+       3.846408252378503*^9}, CellLabel -> "Out[62]=", ExpressionUUID -> "36ad64db-329f-490b-b04e-505146c262de"
+      ]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{"Numeric",
+       " ", "examples"}], "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ToPython",
+       "[", "2", "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[", RowBox[
+      {"1", "/", "3"}], "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[",
+       RowBox[{"1.0", "/", "3"}], "]"}], "\[IndentingNewLine]", RowBox[{"ToPython",
+       "[", "2.31", "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[", 
+      RowBox[{"2.31", "+", RowBox[{"5.3", "I"}]}], "]"}]}]}]], "Input", CellChangeTimes
+       -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020708510957*^9}, {3.817041939215971*^9, 3.817041941599523*^9}},
+       CellLabel -> "In[63]:=", ExpressionUUID -> "5185dd86-dec4-4c26-8e48-124321882ccc"
+      ], Cell[BoxData["\<\"2\"\>"], "Output", CellChangeTimes -> {{3.8348254307300167`*^9,
+       3.834825457566633*^9}, 3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9,
+       3.8460423458778563`*^9, 3.846408252420711*^9}, CellLabel -> "Out[63]=",
+       ExpressionUUID -> "34ff0311-ced8-4ed5-9f19-3c5c313b48f6"], Cell[BoxData[
+      "\<\"0.3333333333333333\"\>"], "Output", CellChangeTimes -> {{3.8348254307300167`*^9,
+       3.834825457566633*^9}, 3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9,
+       3.8460423458778563`*^9, 3.846408252422104*^9}, CellLabel -> "Out[64]=",
+       ExpressionUUID -> "ff1f2ab9-65bf-440e-b271-3b059595e619"], Cell[BoxData[
+      "\<\"0.3333333333333333\"\>"], "Output", CellChangeTimes -> {{3.8348254307300167`*^9,
+       3.834825457566633*^9}, 3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9,
+       3.8460423458778563`*^9, 3.846408252423403*^9}, CellLabel -> "Out[65]=",
+       ExpressionUUID -> "6fc6c7d0-110c-40e4-8004-48f597b8237b"], Cell[BoxData[
+      "\<\"2.31\"\>"], "Output", CellChangeTimes -> {{3.8348254307300167`*^9,
+       3.834825457566633*^9}, 3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9,
+       3.8460423458778563`*^9, 3.846408252424692*^9}, CellLabel -> "Out[66]=",
+       ExpressionUUID -> "5eba5c6f-d861-48ec-a19b-61235d4295b0"], Cell[BoxData[
+      "\<\"complex(2.31, 5.3)\"\>"], "Output", CellChangeTimes -> {{3.8348254307300167`*^9,
+       3.834825457566633*^9}, 3.834825494730929*^9, 3.834825655900078*^9, 3.846041872712222*^9,
+       3.8460423458778563`*^9, 3.846408252426001*^9}, CellLabel -> "Out[67]=",
+       ExpressionUUID -> "663903c8-b170-4217-9afb-bef9f743e2c2"]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{"Array",
+       " ", "handling"}], "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ToPython",
+       "[", RowBox[{"{", RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], "\[IndentingNewLine]",
+       RowBox[{"ToPython", "[", RowBox[{"{", RowBox[{"{", RowBox[{"1", ",",
+       "2", ",", "3"}], "}"}], "}"}], "]"}], "\[IndentingNewLine]", RowBox[
+      {"ToPython", "[", RowBox[{"Cos", "[", RowBox[{"{", RowBox[{"1", ",", 
+      "2", ",", "3"}], "}"}], "]"}], "]"}]}]}]], "Input", CellChangeTimes ->
+       {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020703952483*^9}, {3.817042042716785*^9, 3.817042043976235*^9}},
+       CellLabel -> "In[68]:=", ExpressionUUID -> "292185a9-2fb5-4cee-ba04-979e10b4d536"
+      ], Cell[BoxData["\<\"np.array([1, 2, 3])\"\>"], "Output", CellChangeTimes
+       -> {{3.834825430781938*^9, 3.834825457577856*^9}, 3.834825494779072*^9,
+       3.834825655944306*^9, 3.846041872722941*^9, 3.846042345888381*^9, 3.84640825243394*^9
+      }, CellLabel -> "Out[68]=", ExpressionUUID -> "0112898f-b97d-40ac-bad5-e08df00d59e5"
+      ], Cell[BoxData["\<\"np.array([np.array([1, 2, 3])])\"\>"], "Output",
+       CellChangeTimes -> {{3.834825430781938*^9, 3.834825457577856*^9}, 3.834825494779072*^9,
+       3.834825655944306*^9, 3.846041872722941*^9, 3.846042345888381*^9, 3.846408252436035*^9
+      }, CellLabel -> "Out[69]=", ExpressionUUID -> "2b10b530-5d6c-45a1-a3d1-849cbde2b60f"
+      ], Cell[BoxData["\<\"np.array([np.cos(1), np.cos(2), np.cos(3)])\"\>"
+      ], "Output", CellChangeTimes -> {{3.834825430781938*^9, 3.834825457577856*^9
+      }, 3.834825494779072*^9, 3.834825655944306*^9, 3.846041872722941*^9, 
+      3.846042345888381*^9, 3.8464082524375343`*^9}, CellLabel -> "Out[70]=",
+       ExpressionUUID -> "7147813f-8b02-496b-9047-a3c10754db26"]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{"Example",
+       " ", "with", " ", "numpy", " ", "as", " ", "numpy"}], "*)"}], "\[IndentingNewLine]",
+       RowBox[{RowBox[{"ToPython", "[", RowBox[{RowBox[{"\[Pi]", " ", RowBox[
+      {RowBox[{"Cosh", "[", "a", "]"}], "/", RowBox[{"Sin", "[", "b", "]"}]
+      }]}], ",", RowBox[{"NumpyPrefix", "\[Rule]", " ", "\"\<numpy\>\""}]}],
+       "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[", RowBox[{RowBox[
+      {"Exp", "[", RowBox[{"a", "+", "b"}], "]"}], ",", RowBox[{"NumpyPrefix",
+       "\[Rule]", " ", "\"\<numpy\>\""}]}], "]"}], "\[IndentingNewLine]", RowBox[
+      {"ToPython", "[", RowBox[{RowBox[{"Cos", "[", RowBox[{"{", RowBox[{"1",
+       ",", "2", ",", "3"}], "}"}], "]"}], ",", RowBox[{"NumpyPrefix", "\[Rule]",
+       " ", "\"\<numpy\>\""}]}], "]"}]}]}]], "Input", CellChangeTimes -> {{
+      3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9, 3.817020699758286*^9
+      }, {3.817042046873148*^9, 3.817042048134284*^9}, {3.834825479111014*^9,
+       3.834825486108267*^9}}, CellLabel -> "In[71]:=", ExpressionUUID -> "f6527cd2-52e4-49a6-9b6c-bc9c98edc4bd"
+      ], Cell[BoxData["\<\"numpy.pi * numpy.cosh(a) * (1 / numpy.sin(b))\"\>"
+      ], "Output", CellChangeTimes -> {{3.834825430790345*^9, 3.834825457619651*^9
+      }, 3.834825494795306*^9, 3.834825655952808*^9, 3.846041872762762*^9, 
+      3.846042345931856*^9, 3.846408252478046*^9}, CellLabel -> "Out[71]=",
+       ExpressionUUID -> "45383448-7da3-4bb2-aa79-fa57c9eba20f"], Cell[BoxData[
+      "\<\"numpy.exp(a + b)\"\>"], "Output", CellChangeTimes -> {{3.834825430790345*^9,
+       3.834825457619651*^9}, 3.834825494795306*^9, 3.834825655952808*^9, 3.846041872762762*^9,
+       3.846042345931856*^9, 3.846408252479697*^9}, CellLabel -> "Out[72]=",
+       ExpressionUUID -> "2bd16af2-3be7-4a2b-b41f-1c66aca38621"], Cell[BoxData[
+      "\<\"numpy.array([numpy.cos(1), numpy.cos(2), numpy.cos(3)])\"\>"], "Output",
+       CellChangeTimes -> {{3.834825430790345*^9, 3.834825457619651*^9}, 3.834825494795306*^9,
+       3.834825655952808*^9, 3.846041872762762*^9, 3.846042345931856*^9, 3.846408252481016*^9
+      }, CellLabel -> "Out[73]=", ExpressionUUID -> "06fee358-9a64-4080-a1b6-347d5d7f63c8"
+      ]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{"Example",
+       " ", "with", " ", "numpy", " ", "as", " ", "\"\<from numpy import *\>\""
+      }], "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ToPython", "[", RowBox[
+      {RowBox[{"\[Pi]", " ", RowBox[{RowBox[{"Cosh", "[", "a", "]"}], "/", 
+      RowBox[{"Sin", "[", "b", "]"}]}]}], ",", RowBox[{"NumpyPrefix", "\[Rule]",
+       "\"\<\>\""}]}], "]"}], "\[IndentingNewLine]", RowBox[{"ToPython", "[",
+       RowBox[{RowBox[{"Exp", "[", RowBox[{"a", "+", "b"}], "]"}], ",", RowBox[
+      {"NumpyPrefix", "\[Rule]", "\"\<\>\""}]}], "]"}], "\[IndentingNewLine]",
+       RowBox[{"ToPython", "[", RowBox[{RowBox[{"Cos", "[", RowBox[{"{", RowBox[
+      {"1", ",", "2", ",", "3"}], "}"}], "]"}], ",", RowBox[{"NumpyPrefix",
+       "\[Rule]", "\"\<\>\""}]}], "]"}]}]}]], "Input", CellChangeTimes -> {
+      {3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9, 
+      3.817020694983716*^9}, {3.846408271620933*^9, 3.8464082821115227`*^9}
+      }, CellLabel -> "In[83]:=", ExpressionUUID -> "5515cb8d-3b4a-4f07-909f-e82f28173e96"
+      ], Cell[BoxData["\<\"pi * cosh(a) * (1 / sin(b))\"\>"], "Output", CellChangeTimes
+       -> {{3.8348254308298597`*^9, 3.8348254576304607`*^9}, 3.834825494839604*^9,
+       3.834825655996907*^9, 3.846041872772156*^9, 3.8460423459407063`*^9, 
+      {3.846408252488163*^9, 3.846408282512183*^9}}, CellLabel -> "Out[83]=",
+       ExpressionUUID -> "240ed9f5-031a-433b-b506-e4041a7c85e9"], Cell[BoxData[
+      "\<\"exp(a + b)\"\>"], "Output", CellChangeTimes -> {{3.8348254308298597`*^9,
+       3.8348254576304607`*^9}, 3.834825494839604*^9, 3.834825655996907*^9,
+       3.846041872772156*^9, 3.8460423459407063`*^9, {3.846408252488163*^9,
+       3.8464082825143633`*^9}}, CellLabel -> "Out[84]=", ExpressionUUID ->
+       "2328c139-66f6-433b-9b3f-558e02b8de97"], Cell[BoxData["\<\"array([cos(1), cos(2), cos(3)])\"\>"
+      ], "Output", CellChangeTimes -> {{3.8348254308298597`*^9, 3.8348254576304607`*^9
+      }, 3.834825494839604*^9, 3.834825655996907*^9, 3.846041872772156*^9, 
+      3.8460423459407063`*^9, {3.846408252488163*^9, 3.846408282516893*^9}},
+       CellLabel -> "Out[85]=", ExpressionUUID -> "738a495d-78bf-4d91-84db-aa6df0d4f9c6"
+      ]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", " ", RowBox[
+      {"Special", " ", "functions"}], " ", "*)"}], "\[IndentingNewLine]", RowBox[
+      {"ToPython", "[", RowBox[{"SphericalHarmonicY", "[", RowBox[{"l", ",",
+       "m", ",", "\[Theta]", ",", "\[Phi]"}], "]"}], "]"}]}]], "Input", CellChangeTimes
+       -> {{3.8171174664415627`*^9, 3.8171175150332823`*^9}}, CellLabel -> 
+      "In[77]:=", ExpressionUUID -> "0e4529e0-9456-4a42-870d-172c1748c68e"],
+       Cell[BoxData["\<\"special.sph_harm(m, l, (phi) % (2 * np.pi), (theta) % np.pi)\"\>"
+      ], "Output", CellChangeTimes -> {{3.8348254308381367`*^9, 3.8348254576675386`*^9
+      }, 3.8348254948487988`*^9, 3.834825656005947*^9, 3.846041872817704*^9,
+       3.846042345983569*^9, 3.846408252528775*^9}, CellLabel -> "Out[77]=",
+       ExpressionUUID -> "4ae6d35d-df52-4700-92a8-95c90f0e39a4"]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{"ToPython", "[", RowBox[
+      {"Sqrt", "[", "a", "]"}], "]"}]], "Input", CellChangeTimes -> {{3.817120078799831*^9,
+       3.817120082942841*^9}}, CellLabel -> "In[78]:=", ExpressionUUID -> "0ae939ea-d5e9-419b-999a-64601c326ce5"
+      ], Cell[BoxData["\<\"np.sqrt(a)\"\>"], "Output", CellChangeTimes -> {
+      {3.834825430844825*^9, 3.8348254576733294`*^9}, 3.834825494889243*^9,
+       3.834825656045374*^9, 3.846041872824448*^9, 3.84604234598946*^9, 3.846408252535535*^9
+      }, CellLabel -> "Out[78]=", ExpressionUUID -> "85a68d86-e2b6-4a71-9623-f36bf1d145f4"
+      ]}, Open]]
+    ,
+    Cell[CellGroupData[{Cell[BoxData[RowBox[{"ToPython", "[", RowBox[
+      {"{", RowBox[{"1", ",", "2", ",", RowBox[{"a", "+", "b", "+", RowBox[
+      {"Sin", "[", "x", "]"}]}]}], "}"}], "]"}]], "Input", CellChangeTimes 
+      -> {{3.8171328786925697`*^9, 3.8171328909644003`*^9}}, CellLabel -> "In[79]:=",
+       ExpressionUUID -> "096db8ac-16bc-4502-968b-388523b12c99"], Cell[BoxData[
+      "\<\"np.array([1, 2, a + b + np.sin(x)])\"\>"], "Output", CellChangeTimes
+       -> {{3.834825430851001*^9, 3.834825457706586*^9}, 3.8348254948948517`*^9,
+       3.83482565605092*^9, 3.846041872873*^9, 3.846042346027454*^9, 3.846408252582428*^9
+      }, CellLabel -> "Out[79]=", ExpressionUUID -> "70a28131-2827-4521-9b2f-3564cb142e37"
+      ]}, Open]]
+  }
+  ,
+  WindowSize -> {808, 701}
+  ,
+  WindowMargins -> {{Automatic, 150}, {Automatic, 131}}
+  ,
+  FrontEndVersion -> "12.1 for Mac OS X x86 (64-bit) (March 13, 2020)"
+    
+  ,
+  StyleDefinitions -> "Default.nb"
+  ,
+  ExpressionUUID -> "798b0806-392b-4800-9dba-1ecc8fa5714a"
 ]
+
 (* End of Notebook Content *)
 
 (* Internal cache information *)
+
 (*CellTagsOutline
 CellTagsIndex->{}
 *)
+
 (*CellTagsIndex
 CellTagsIndex->{}
 *)
+
 (*NotebookFileOutline
 Notebook[{
 Cell[558, 20, 686, 15, 52, "Input",ExpressionUUID->"ee6242fe-5738-42d7-927d-12c3be9f45f8"],
@@ -1657,4 +950,3 @@ Cell[71763, 1566, 331, 4, 34, "Output",ExpressionUUID->"70a28131-2827-4521-9b2f-
 }
 ]
 *)
-

--- a/ToPython_tests.nb
+++ b/ToPython_tests.nb
@@ -1,11 +1,13 @@
 (* Content-type: application/vnd.wolfram.mathematica *)
 
 (*** Wolfram Notebook File ***)
+
 (* http://www.wolfram.com/nb *)
 
 (* CreatedBy='Mathematica 11.0' *)
 
 (*CacheID: 234*)
+
 (* Internal cache information:
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
@@ -17,1453 +19,1039 @@ CellTagsIndexPosition[     68477,       1464]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
-Notebook[{
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", 
-   RowBox[{
-    RowBox[{"loads", " ", "the", " ", "package"}], " ", "-", " ", 
-    RowBox[{"after", " ", "installation"}]}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"ClearAll", "[", "\"\<Global`*\>\"", "]"}], "\[IndentingNewLine]", 
-   
-   RowBox[{"Get", "@", 
-    RowBox[{"FileNameJoin", "[", 
-     RowBox[{"{", 
-      RowBox[{
-       RowBox[{"NotebookDirectory", "[", "]"}], ",", "\"\<ToPython.wl\>\""}], 
-      "}"}], "]"}]}]}]}]], "Input",
- CellChangeTimes->{{3.70181767476367*^9, 3.701817694205203*^9}, {
-  3.7018181976937943`*^9, 3.701818211998588*^9}, {3.817007877025469*^9, 
-  3.81700790447239*^9}, {3.817220388658033*^9, 3.817220409587041*^9}, {
-  3.817221007872984*^9, 3.817221033503044*^9}, {3.817221066267579*^9, 
-  3.817221086744882*^9}},
- CellLabel->"In[1]:=",ExpressionUUID->"ee6242fe-5738-42d7-927d-12c3be9f45f8"],
 
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", " ", 
-   RowBox[{
-   "Adjust", " ", "this", " ", "path", " ", "to", " ", "your", " ", "python", 
-    " ", "interpreter"}], " ", "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"pythonPath", "=", "\"\</opt/local/bin/python3\>\""}], 
-   ";"}]}]], "Input",
- CellChangeTimes->{{3.817221410879698*^9, 3.817221418419937*^9}, {
-  3.81722144914742*^9, 3.81722147152433*^9}},
- CellLabel->"In[3]:=",ExpressionUUID->"b874d894-ea09-439a-90db-628140ef50ad"],
-
-Cell[CellGroupData[{
-
-Cell["Test infrastructure", "Section",
- CellChangeTimes->{{3.846042068107306*^9, 
-  3.84604207224017*^9}},ExpressionUUID->"7b6e915e-b4c7-474a-aaf3-\
-aecc99a4e24d"],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", " ", 
-   RowBox[{
-   "Pick", " ", "some", " ", "values", " ", "and", " ", "initialize", " ", 
-    "the", " ", "python", " ", "evaluator"}], " ", "*)"}], 
-  "\[IndentingNewLine]", 
-  RowBox[{"vals", "=", 
-   RowBox[{"{", 
-    RowBox[{
-     RowBox[{"a", "\[Rule]", "1"}], ",", 
-     RowBox[{"b", "\[Rule]", "2"}], ",", 
-     RowBox[{"c", "\[Rule]", 
-      RowBox[{"RandomReal", "[", "]"}]}], ",", 
-     RowBox[{"d", "\[Rule]", 
-      RowBox[{"RandomReal", "[", "]"}]}], ",", 
-     RowBox[{"e", "\[Rule]", 
-      RowBox[{"RandomReal", "[", "]"}]}], ",", 
-     RowBox[{"g", "\[Rule]", 
-      RowBox[{"RandomReal", "[", "]"}]}]}], "}"}]}]}]], "Input",
- CellChangeTimes->{{3.8170415720331717`*^9, 3.817041663288992*^9}, {
-  3.8170422146371593`*^9, 3.817042243683446*^9}, {3.817119417702676*^9, 
-  3.817119423221958*^9}, {3.8172200443350983`*^9, 3.817220088496299*^9}, {
-  3.817220538077466*^9, 3.817220539134753*^9}},
- CellLabel->"In[4]:=",ExpressionUUID->"be172ae8-6ece-4aaf-9126-d625e8d00a59"],
-
-Cell[BoxData[
- RowBox[{"{", 
-  RowBox[{
-   RowBox[{"a", "\[Rule]", "1"}], ",", 
-   RowBox[{"b", "\[Rule]", "2"}], ",", 
-   RowBox[{"c", "\[Rule]", "0.607399570102088`"}], ",", 
-   RowBox[{"d", "\[Rule]", "0.7489446113292975`"}], ",", 
-   RowBox[{"e", "\[Rule]", "0.7095969870653862`"}], ",", 
-   RowBox[{"g", "\[Rule]", "0.21674371595706687`"}]}], "}"}]], "Output",
- CellChangeTimes->{
-  3.834825663428466*^9, 3.846040776783359*^9, 3.8460410046161013`*^9, 
-   3.8460417773639402`*^9, 3.846041884040916*^9, {3.8460420779687443`*^9, 
-   3.8460420902269*^9}, 3.846042311515045*^9, 3.846158304014421*^9, 
-   3.8461667208505163`*^9, 3.8464079831186533`*^9, 3.846408146365361*^9, 
-   3.846408235785553*^9},
- CellLabel->"Out[4]=",ExpressionUUID->"27a592f9-7d00-4126-bc05-25ce5f6c16e2"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", " ", 
-   RowBox[{
-   "Start", " ", "a", " ", "python", " ", "shell", " ", "do", " ", "evaluate",
-     " ", "commands"}], " ", "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"session", "=", 
-    RowBox[{"StartExternalSession", "[", 
-     RowBox[{"<|", 
-      RowBox[{
-       RowBox[{"\"\<System\>\"", "\[Rule]", "\"\<Python\>\""}], ",", 
-       RowBox[{"\"\<Executable\>\"", "\[Rule]", "pythonPath"}]}], "|>"}], 
-     "]"}]}], "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"init", "=", 
-     RowBox[{"StringRiffle", "[", 
-      RowBox[{
-       RowBox[{"Map", "[", 
-        RowBox[{
-         RowBox[{
-          RowBox[{
-           RowBox[{"ToString", "[", 
-            RowBox[{"#", "[", 
-             RowBox[{"[", "1", "]"}], "]"}], "]"}], "<>", "\"\<=\>\"", "<>", 
-           RowBox[{"ToString", "[", 
-            RowBox[{
-             RowBox[{"#", "[", 
-              RowBox[{"[", "2", "]"}], "]"}], ",", "FortranForm"}], "]"}]}], 
-          "&"}], ",", "vals"}], "]"}], ",", " ", "\"\<;\>\""}], "]"}]}], 
-    ";"}], "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"ExternalEvaluate", "[", 
-     RowBox[{"session", ",", "\"\<import numpy as np\>\""}], "]"}], ";"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"ExternalEvaluate", "[", 
-     RowBox[{"session", ",", "\"\<from scipy import special\>\""}], "]"}], 
-    ";"}], "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"ExternalEvaluate", "[", 
-     RowBox[{"session", ",", "init"}], "]"}], ";"}]}]}]], "Input",
- CellChangeTimes->{{3.8170415720331717`*^9, 3.817041663288992*^9}, {
-   3.8170422146371593`*^9, 3.817042243683446*^9}, {3.817119417702676*^9, 
-   3.817119423221958*^9}, {3.8172200443350983`*^9, 3.817220081853519*^9}, {
-   3.817220200706709*^9, 3.8172202130659523`*^9}, {3.81722142464642*^9, 
-   3.817221436366208*^9}, 3.817273597531622*^9},
- CellLabel->"In[5]:=",ExpressionUUID->"2df5bef7-4ce7-41a3-919a-c19df456e2f3"],
-
-Cell[BoxData[
- InterpretationBox[
-  RowBox[{
-   TagBox["ExternalSessionObject",
-    "SummaryHead"], "[", 
-   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+Notebook[
+  {
+    Cell[BoxData[RowBox[{RowBox[{"(*", RowBox[{RowBox[{"loads", " ", 
+      "the", " ", "package"}], " ", "-", " ", RowBox[{"after", " ", "installation"
+      }]}], "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ClearAll", "[",
+       "\"\<Global`*\>\"", "]"}], "\[IndentingNewLine]", RowBox[{"Get", "@",
+       RowBox[{"FileNameJoin", "[", RowBox[{"{", RowBox[{RowBox[{"NotebookDirectory",
+       "[", "]"}], ",", "\"\<ToPython.wl\>\""}], "}"}], "]"}]}]}]}]], "Input",
+       CellChangeTimes -> {{3.70181767476367*^9, 3.701817694205203*^9}, {3.7018181976937943`*^9,
+       3.701818211998588*^9}, {3.817007877025469*^9, 3.81700790447239*^9}, 
+      {3.817220388658033*^9, 3.817220409587041*^9}, {3.817221007872984*^9, 
+      3.817221033503044*^9}, {3.817221066267579*^9, 3.817221086744882*^9}},
+       CellLabel -> "In[1]:=", ExpressionUUID -> "ee6242fe-5738-42d7-927d-12c3be9f45f8"
+      ]
+    ,
+    Cell[BoxData[RowBox[{RowBox[{"(*", " ", RowBox[{"Adjust", " ", "this",
+       " ", "path", " ", "to", " ", "your", " ", "python", " ", "interpreter"
+      }], " ", "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"pythonPath",
+       "=", "\"\</opt/local/bin/python3\>\""}], ";"}]}]], "Input", CellChangeTimes
+       -> {{3.817221410879698*^9, 3.817221418419937*^9}, {3.81722144914742*^9,
+       3.81722147152433*^9}}, CellLabel -> "In[3]:=", ExpressionUUID -> "b874d894-ea09-439a-90db-628140ef50ad"
+      ]
+    ,
+    Cell[
+      CellGroupData[
+        {
+          Cell["Test infrastructure", "Section", CellChangeTimes -> {
+            {3.846042068107306*^9, 3.84604207224017*^9}}, ExpressionUUID -> "7b6e915e-b4c7-474a-aaf3-aecc99a4e24d"
+            ]
+          ,
+          Cell[CellGroupData[{Cell[BoxData[RowBox[{RowBox[{"(*", " ",
+             RowBox[{"Pick", " ", "some", " ", "values", " ", "and", " ", "initialize",
+             " ", "the", " ", "python", " ", "evaluator"}], " ", "*)"}], "\[IndentingNewLine]",
+             RowBox[{"vals", "=", RowBox[{"{", RowBox[{RowBox[{"a", "\[Rule]", "1"
+            }], ",", RowBox[{"b", "\[Rule]", "2"}], ",", RowBox[{"c", "\[Rule]", 
+            RowBox[{"RandomReal", "[", "]"}]}], ",", RowBox[{"d", "\[Rule]", RowBox[
+            {"RandomReal", "[", "]"}]}], ",", RowBox[{"e", "\[Rule]", RowBox[{"RandomReal",
+             "[", "]"}]}], ",", RowBox[{"g", "\[Rule]", RowBox[{"RandomReal", "[",
+             "]"}]}]}], "}"}]}]}]], "Input", CellChangeTimes -> {{3.8170415720331717`*^9,
+             3.817041663288992*^9}, {3.8170422146371593`*^9, 3.817042243683446*^9
+            }, {3.817119417702676*^9, 3.817119423221958*^9}, {3.8172200443350983`*^9,
+             3.817220088496299*^9}, {3.817220538077466*^9, 3.817220539134753*^9}},
+             CellLabel -> "In[4]:=", ExpressionUUID -> "be172ae8-6ece-4aaf-9126-d625e8d00a59"
+            ], Cell[BoxData[RowBox[{"{", RowBox[{RowBox[{"a", "\[Rule]", "1"}], ",",
+             RowBox[{"b", "\[Rule]", "2"}], ",", RowBox[{"c", "\[Rule]", "0.607399570102088`"
+            }], ",", RowBox[{"d", "\[Rule]", "0.7489446113292975`"}], ",", RowBox[
+            {"e", "\[Rule]", "0.7095969870653862`"}], ",", RowBox[{"g", "\[Rule]",
+             "0.21674371595706687`"}]}], "}"}]], "Output", CellChangeTimes -> {3.834825663428466*^9,
+             3.846040776783359*^9, 3.8460410046161013`*^9, 3.8460417773639402`*^9,
+             3.846041884040916*^9, {3.8460420779687443`*^9, 3.8460420902269*^9}, 
+            3.846042311515045*^9, 3.846158304014421*^9, 3.8461667208505163`*^9, 3.8464079831186533`*^9,
+             3.846408146365361*^9, 3.846408235785553*^9}, CellLabel -> "Out[4]=",
+             ExpressionUUID -> "27a592f9-7d00-4126-bc05-25ce5f6c16e2"]}, Open]]
+          ,
+          Cell[
+            CellGroupData[
+              {
+                Cell[BoxData[RowBox[{RowBox[{"(*", " ", RowBox[{"Start",
+                   " ", "a", " ", "python", " ", "shell", " ", "do", " ", "evaluate", " ",
+                   "commands"}], " ", "*)"}], "\[IndentingNewLine]", RowBox[{RowBox[{"session",
+                   "=", RowBox[{"StartExternalSession", "[", RowBox[{"<|", RowBox[{RowBox[
+                  {"\"\<System\>\"", "\[Rule]", "\"\<Python\>\""}], ",", RowBox[{"\"\<Executable\>\"",
+                   "\[Rule]", "pythonPath"}]}], "|>"}], "]"}]}], "\[IndentingNewLine]",
+                   RowBox[{RowBox[{"init", "=", RowBox[{"StringRiffle", "[", RowBox[{RowBox[
+                  {"Map", "[", RowBox[{RowBox[{RowBox[{RowBox[{"ToString", "[", RowBox[
+                  {"#", "[", RowBox[{"[", "1", "]"}], "]"}], "]"}], "<>", "\"\<=\>\"", 
+                  "<>", RowBox[{"ToString", "[", RowBox[{RowBox[{"#", "[", RowBox[{"[",
+                   "2", "]"}], "]"}], ",", "FortranForm"}], "]"}]}], "&"}], ",", "vals"
+                  }], "]"}], ",", " ", "\"\<;\>\""}], "]"}]}], ";"}], "\[IndentingNewLine]",
+                   RowBox[{RowBox[{"ExternalEvaluate", "[", RowBox[{"session", ",", "\"\<import numpy as np\>\""
+                  }], "]"}], ";"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ExternalEvaluate",
+                   "[", RowBox[{"session", ",", "\"\<from scipy import special\>\""}], 
+                  "]"}], ";"}], "\[IndentingNewLine]", RowBox[{RowBox[{"ExternalEvaluate",
+                   "[", RowBox[{"session", ",", "init"}], "]"}], ";"}]}]}]], "Input", CellChangeTimes
+                   -> {{3.8170415720331717`*^9, 3.817041663288992*^9}, {3.8170422146371593`*^9,
+                   3.817042243683446*^9}, {3.817119417702676*^9, 3.817119423221958*^9},
+                   {3.8172200443350983`*^9, 3.817220081853519*^9}, {3.817220200706709*^9,
+                   3.8172202130659523`*^9}, {3.81722142464642*^9, 3.817221436366208*^9},
+                   3.817273597531622*^9}, CellLabel -> "In[5]:=", ExpressionUUID -> "2df5bef7-4ce7-41a3-919a-c19df456e2f3"
+                  ]
+                ,
+                Cell[
+                  BoxData[
+                    InterpretationBox[
+                      RowBox[
+                        {
+                          TagBox["ExternalSessionObject", "SummaryHead"
+                            ]
+                          ,
+                          "["
+                          ,
+                          DynamicModuleBox[
+                            {Typeset`open$$ = False, Typeset`embedState$$
+                               = "Ready"}
+                            ,
+                            TemplateBox[
+                              {
+                                PaneSelectorBox[
+                                  {
+                                    False -> GridBox[{{PaneBox[ButtonBox[
+                                      DynamicBox[FEPrivate`FrontEndResource["FEBitmaps", "SquarePlusIconMedium"
+                                      ]], ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, Evaluator
+                                       -> Automatic, Method -> "Preemptive"], Alignment -> {Center, Center},
+                                       ImageSize -> Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"] /
+                                       AbsoluteCurrentValue[Magnification]}]], GraphicsBox[{{Hue[0.5766283524904214,
+                                       0.6682027649769585, 0.651], EdgeForm[None], FilledCurveBox[{{{1, 4, 
+                                      3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 1, 0
+                                      }, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, 
+                                      {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{58, 120},
+                                       {60, 120}, {62, 118}, {62, 115}, {62, 112}, {60, 110}, {58, 110}, {55,
+                                       110}, {53, 112}, {53, 115}, {53, 118}, {55, 120}, {58, 120}}, {{72, 
+                                      128}, {44, 128}, {46, 116}, {46, 116}, {46, 104}, {73, 104}, {73, 100
+                                      }, {36, 100}, {36, 100}, {18, 102}, {18, 74}, {18, 45}, {33, 46}, {33,
+                                       46}, {43, 46}, {43, 59}, {43, 59}, {42, 75}, {58, 75}, {85, 75}, {85,
+                                       75}, {99, 75}, {99, 89}, {99, 114}, {99, 114}, {102, 128}, {72, 128}
+                                      }}]}, {Hue[0.1164, 0.745, 0.99], EdgeForm[None], FilledCurveBox[{{{1,
+                                       4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 
+                                      1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 
+                                      0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{88, 27
+                                      }, {85, 27}, {83, 29}, {83, 32}, {83, 34}, {85, 37}, {88, 37}, {91, 37
+                                      }, {93, 34}, {93, 32}, {93, 29}, {91, 27}, {88, 27}}, {{73, 18}, {101,
+                                       18}, {99, 31}, {99, 31}, {99, 43}, {73, 43}, {73, 47}, {110, 47}, {110,
+                                       47}, {128, 45}, {128, 73}, {128, 102}, {112, 101}, {112, 101}, {103,
+                                       101}, {103, 87}, {103, 87}, {104, 72}, {88, 72}, {61, 72}, {61, 72},
+                                       {46, 72}, {46, 57}, {46, 33}, {46, 33}, {44, 18}, {73, 18}}}]}}, {ImageSize
+                                       -> {Automatic, Dynamic[3.5 CurrentValue["FontCapHeight"]]}, ImageSize
+                                       -> {Automatic, Dynamic[3.5 CurrentValue["FontCapHeight"]]}}], GridBox[
+                                      {{RowBox[{TagBox["\"System: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]",
+                                       TagBox["\"Python\"", "SummaryItem"]}], RowBox[{TagBox["\"Version: \"",
+                                       "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"3.7.9\"", "SummaryItem"
+                                      ]}]}, {RowBox[{TagBox["\"UUID: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]",
+                                       TagBox["\"9d054758-6742-4dc1-bdf0-92cfab26dc91\"", "SummaryItem"]}],
+                                       "\[SpanFromLeft]"}}, GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows"
+                                       -> {{Automatic}}}, AutoDelete -> False, GridBoxItemSize -> {"Columns"
+                                       -> {{Automatic}}, "Rows" -> {{Automatic}}}, GridBoxSpacings -> {"Columns"
+                                       -> {{2}}, "Rows" -> {{Automatic}}}, BaseStyle -> {ShowStringCharacters
+                                       -> False, NumberMarks -> False, PrintPrecision -> 3, ShowSyntaxStyles
+                                       -> False}]}}, GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete ->
+                                       False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic
+                                      }}}, BaselinePosition -> {1, 1}]
+                                    ,
+                                    True ->
+                                      GridBox[
+                                        {
+                                          {
+                                            PaneBox[ButtonBox[DynamicBox[
+                                              FEPrivate`FrontEndResource["FEBitmaps", "SquareMinusIconMedium"]], ButtonFunction
+                                               :> (Typeset`open$$ = False), Appearance -> None, Evaluator -> Automatic,
+                                               Method -> "Preemptive"], Alignment -> {Center, Center}, ImageSize ->
+                                               Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"] / AbsoluteCurrentValue[
+                                              Magnification]}]]
+                                            ,
+                                            GraphicsBox[{{Hue[0.5766283524904214,
+                                               0.6682027649769585, 0.651], EdgeForm[None], FilledCurveBox[{{{1, 4, 
+                                              3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 1, 0
+                                              }, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, 
+                                              {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{58, 120},
+                                               {60, 120}, {62, 118}, {62, 115}, {62, 112}, {60, 110}, {58, 110}, {55,
+                                               110}, {53, 112}, {53, 115}, {53, 118}, {55, 120}, {58, 120}}, {{72, 
+                                              128}, {44, 128}, {46, 116}, {46, 116}, {46, 104}, {73, 104}, {73, 100
+                                              }, {36, 100}, {36, 100}, {18, 102}, {18, 74}, {18, 45}, {33, 46}, {33,
+                                               46}, {43, 46}, {43, 59}, {43, 59}, {42, 75}, {58, 75}, {85, 75}, {85,
+                                               75}, {99, 75}, {99, 89}, {99, 114}, {99, 114}, {102, 128}, {72, 128}
+                                              }}]}, {Hue[0.1164, 0.745, 0.99], EdgeForm[None], FilledCurveBox[{{{1,
+                                               4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 
+                                              1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 
+                                              0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{88, 27
+                                              }, {85, 27}, {83, 29}, {83, 32}, {83, 34}, {85, 37}, {88, 37}, {91, 37
+                                              }, {93, 34}, {93, 32}, {93, 29}, {91, 27}, {88, 27}}, {{73, 18}, {101,
+                                               18}, {99, 31}, {99, 31}, {99, 43}, {73, 43}, {73, 47}, {110, 47}, {110,
+                                               47}, {128, 45}, {128, 73}, {128, 102}, {112, 101}, {112, 101}, {103,
+                                               101}, {103, 87}, {103, 87}, {104, 72}, {88, 72}, {61, 72}, {61, 72},
+                                               {46, 72}, {46, 57}, {46, 33}, {46, 33}, {44, 18}, {73, 18}}}]}}, {ImageSize
+                                               -> {Automatic, Dynamic[3.5 CurrentValue["FontCapHeight"]]}, ImageSize
+                                               -> {Automatic, Dynamic[3.5 CurrentValue["FontCapHeight"]]}}]
+                                            ,
+                                            GridBox[
+                                              {
+                                                {RowBox[{TagBox["\"System: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"Python\"", 
+                                                  "SummaryItem"]}]}
+                                                ,
+                                                {RowBox[{TagBox["\"Version: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"3.7.9\"", "SummaryItem"
+                                                  ]}]}
+                                                ,
+                                                {RowBox[{TagBox["\"UUID: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"9d054758-6742-4dc1-bdf0-92cfab26dc91\"",
+                                                   "SummaryItem"]}]}
+                                                ,
+                                                {
+                                                  RowBox[
+                                                    {
+                                                      TagBox["\"Active: \"",
+                                                         "SummaryItemAnnotation"]
+                                                      ,
+                                                      "\[InvisibleSpace]"
+                                                        
+                                                      ,
+                                                      TagBox[
+                                                        DynamicBox[
+                                                          ToBoxes[
+                                                            If[TrueQ[
+                                                              ExternalEvaluate`Private`getSessionOpts["9d054758-6742-4dc1-bdf0-92cfab26dc91",
+                                                               "Exists"]],
+                                                              ExternalSessionObject[
+                                                                "9d054758-6742-4dc1-bdf0-92cfab26dc91"]["Active"]
+                                                              ,
+                                                              False
+                                                            ]
+                                                            ,
+                                                            StandardForm
+                                                              
+                                                          ]
+                                                          ,
+                                                          TrackedSymbols
+                                                             :> {ExternalEvaluate`Private`$Links}
+                                                        ]
+                                                        ,
+                                                        "SummaryItem"
+                                                          
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                                ,
+                                                {RowBox[{TagBox["\"Executable: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"/opt/local/bin/python3\"",
+                                                   "SummaryItem"]}]}
+                                                ,
+                                                {RowBox[{TagBox["\"UUID: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"9d054758-6742-4dc1-bdf0-92cfab26dc91\"",
+                                                   "SummaryItem"]}]}
+                                                ,
+                                                {RowBox[{TagBox["\"Process: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox[InterpretationBox[
+                                                  RowBox[{TagBox["ProcessObject", "SummaryHead"], "[", DynamicModuleBox[
+                                                  {Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, TemplateBox[
+                                                  {PaneSelectorBox[{False -> GridBox[{{PaneBox[ButtonBox[DynamicBox[FEPrivate`FrontEndResource[
+                                                  "FEBitmaps", "SquarePlusIconMedium"]], ButtonFunction :> (Typeset`open$$
+                                                   = True), Appearance -> None, Evaluator -> Automatic, Method -> "Preemptive"
+                                                  ], Alignment -> {Center, Center}, ImageSize -> Dynamic[{Automatic, 3.5
+                                                   CurrentValue["FontCapHeight"] / AbsoluteCurrentValue[Magnification]}
+                                                  ]], GridBox[{{RowBox[{TagBox["\"Program: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox["\"python3.8\"", "SummaryItem"]}]}, {RowBox[
+                                                  {TagBox["\"PID: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox[
+                                                  "85527", "SummaryItem"]}]}}, GridBoxAlignment -> {"Columns" -> {{Left
+                                                  }}, "Rows" -> {{Automatic}}}, AutoDelete -> False, GridBoxItemSize ->
+                                                   {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, GridBoxSpacings
+                                                   -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}}, BaseStyle -> {ShowStringCharacters
+                                                   -> False, NumberMarks -> False, PrintPrecision -> 3, ShowSyntaxStyles
+                                                   -> False}]}}, GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete ->
+                                                   False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic
+                                                  }}}, BaselinePosition -> {1, 1}], True -> GridBox[{{PaneBox[ButtonBox[
+                                                  DynamicBox[FEPrivate`FrontEndResource["FEBitmaps", "SquareMinusIconMedium"
+                                                  ]], ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, Evaluator
+                                                   -> Automatic, Method -> "Preemptive"], Alignment -> {Center, Center},
+                                                   ImageSize -> Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"] /
+                                                   AbsoluteCurrentValue[Magnification]}]], GridBox[{{RowBox[{TagBox["\"Program: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"python3.8\"",
+                                                   "SummaryItem"]}]}, {RowBox[{TagBox["\"PID: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox["85527", "SummaryItem"]}]}, {RowBox[{TagBox[
+                                                  "\"Parent PID: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox[
+                                                  "85524", "SummaryItem"]}]}, {RowBox[{TagBox["\"User: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox["\"dzwicker\"", "SummaryItem"]}]}, {RowBox[
+                                                  {TagBox["\"Path: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                                                  TagBox["\"/opt/local/Library/Frameworks/Python.framework/Versions/3.8/Resources/Python.app/Contents/MacOS/Python\"",
+                                                   "SummaryItem"]}]}, {RowBox[{TagBox["\"Memory:\"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox[TemplateBox[{"20.508672`", "\"MB\"", "megabytes",
+                                                   "\"Megabytes\""}, "Quantity", SyntaxForm -> Mod], "SummaryItem"]}]},
+                                                   {RowBox[{TagBox["\"Threads: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]",
+                                                   TagBox["3", "SummaryItem"]}]}, {RowBox[{TagBox["\"Start Time: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox[TemplateBox[{RowBox[{"\"Sat 20 Nov 2021 15:43:58\"",
+                                                   StyleBox[RowBox[{"\"GMT+\"", "\[InvisibleSpace]", StyleBox["1.`", NumberMarks
+                                                   -> False, StripOnInput -> False]}], FontColor -> GrayLevel[0.5]]}], 
+                                                  RowBox[{"DateObject", "[", RowBox[{RowBox[{"{", RowBox[{"2021", ",", 
+                                                  "11", ",", "20", ",", "15", ",", "43", ",", "58.`"}], "}"}], ",", "\"Instant\"",
+                                                   ",", "\"Gregorian\"", ",", "1.`"}], "]"}]}, "DateObject", Editable ->
+                                                   False], "SummaryItem"]}]}, {RowBox[{TagBox["\"System Time: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox[TemplateBox[{"0.1148549999999999988`5.",
+                                                   "\"s\"", "seconds", "\"Seconds\""}, "Quantity", SyntaxForm -> Mod], 
+                                                  "SummaryItem"]}]}, {RowBox[{TagBox["\"User Time: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox[TemplateBox[{"0.2291410000000000113`5.",
+                                                   "\"s\"", "seconds", "\"Seconds\""}, "Quantity", SyntaxForm -> Mod], 
+                                                  "SummaryItem"]}]}, {RowBox[{TagBox["\"Real Time: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox[TemplateBox[{"0", "\"s\"", "seconds", 
+                                                  "\"Seconds\""}, "Quantity", SyntaxForm -> Mod], "SummaryItem"]}]}}, GridBoxAlignment
+                                                   -> {"Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> False,
+                                                   GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic
+                                                  }}}, GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+                                                   BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> False, PrintPrecision
+                                                   -> 3, ShowSyntaxStyles -> False}]}}, GridBoxAlignment -> {"Rows" -> 
+                                                  {{Top}}}, AutoDelete -> False, GridBoxItemSize -> {"Columns" -> {{Automatic
+                                                  }}, "Rows" -> {{Automatic}}}, BaselinePosition -> {1, 1}]}, Dynamic[Typeset`open$$
+                                                  ], ImageSize -> Automatic]}, "SummaryPanel"], DynamicModuleValues :> 
+                                                  {}], "]"}], ProcessObject[Association["ManagedProcess" -> True, "UID"
+                                                   -> 0, "PID" -> 85527, "PPID" -> 85524, "Program" -> "python3.8", "Path"
+                                                   -> "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8",
+                                                   "User" -> "dzwicker", "StartTime" -> DateObject[{2021, 11, 20, 15, 43,
+                                                   58.}, "Instant", "Gregorian", 1.]]], Selectable -> False, Editable ->
+                                                   False, SelectWithContents -> True], "SummaryItem"]}]}
+                                                ,
+                                                {RowBox[{TagBox["\"ReturnType: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"Expression\"",
+                                                   "SummaryItem"]}]}
+                                                ,
+                                                {RowBox[{TagBox["\"Socket: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox[InterpretationBox[
+                                                  RowBox[{TagBox["SocketObject", "SummaryHead"], "[", DynamicModuleBox[
+                                                  {Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, TemplateBox[
+                                                  {PaneSelectorBox[{False -> GridBox[{{PaneBox[ButtonBox[DynamicBox[FEPrivate`FrontEndResource[
+                                                  "FEBitmaps", "SquarePlusIconMedium"]], ButtonFunction :> (Typeset`open$$
+                                                   = True), Appearance -> None, Evaluator -> Automatic, Method -> "Preemptive"
+                                                  ], Alignment -> {Center, Center}, ImageSize -> Dynamic[{Automatic, 3.5
+                                                   CurrentValue["FontCapHeight"] / AbsoluteCurrentValue[Magnification]}
+                                                  ]], GraphicsBox[GeometricTransformationBox[{{{FilledCurveBox[{{Line[{
+                                                  {36.558, 8.569}, {40.947, 8.569}, {40.947, 43.684000000000005`}, {36.558,
+                                                   43.684000000000005`}, {36.558, 8.569}}]}}]}, {FilledCurveBox[{{Line[
+                                                  {{59.053, 8.569}, {63.443, 8.569}, {63.443, 43.684000000000005`}, {59.053,
+                                                   43.684000000000005`}, {59.053, 8.569}}]}}]}, {{FilledCurveBox[{{Line[
+                                                  {{55.487, 8.569}, {56.95, 8.569}, {56.95, 21.188000000000002`}, {55.487,
+                                                   21.188000000000002`}, {55.487, 8.569}}]}}]}, {FilledCurveBox[{{Line[
+                                                  {{52.562, 8.569}, {54.025, 8.569}, {54.025, 21.188000000000002`}, {52.562,
+                                                   21.188000000000002`}, {52.562, 8.569}}]}}]}, {FilledCurveBox[{{Line[
+                                                  {{49.636, 8.569}, {51.099000000000004`, 8.569}, {51.099000000000004`,
+                                                   21.188000000000002`}, {49.636, 21.188000000000002`}, {49.636, 8.569}
+                                                  }]}}]}, {FilledCurveBox[{{Line[{{46.709, 8.569}, {48.172000000000004`,
+                                                   8.569}, {48.172000000000004`, 21.188000000000002`}, {46.709, 21.188000000000002`
+                                                  }, {46.709, 8.569}}]}}]}, {FilledCurveBox[{{Line[{{43.783, 8.569}, {45.246,
+                                                   8.569}, {45.246, 21.188000000000002`}, {43.783, 21.188000000000002`},
+                                                   {43.783, 8.569}}]}}]}}, {FilledCurveBox[{{Line[{{40.947, 4.911}, {59.787000000000006`,
+                                                   4.911}, {59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 4.911
+                                                  }}]}}]}, {FilledCurveBox[{{Line[{{44.057, 31.675}, {56.678000000000004`,
+                                                   31.675}, {56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 31.675
+                                                  }}]}}]}, {FilledCurveBox[{{Line[{{44.057, 43.685}, {56.678000000000004`,
+                                                   43.685}, {56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 43.685
+                                                  }}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {ImageSize -> {Automatic, Dynamic[
+                                                  3.5 CurrentValue["FontCapHeight"] / AbsoluteCurrentValue[Magnification
+                                                  ]]}, PlotRange -> {{20, 80}, {0, 70}}, BaseStyle -> {CacheGraphics ->
+                                                   False}, ImageSize -> 30}], GridBox[{{RowBox[{TagBox["\"IPAddress: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"127.0.0.1\"",
+                                                   "SummaryItem"]}], RowBox[{TagBox["\"Port: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox["\"63781\"", "SummaryItem"]}]}, {RowBox[
+                                                  {TagBox["\"UUID: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                                                  TagBox["\"ZMQ-3ef55c1d-4a9b-4c18-866b-a2c013f75fc7\"", "SummaryItem"]
+                                                  }], RowBox[{TagBox["\"Protocol: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]",
+                                                   TagBox["\"ZMQ_PAIR\"", "SummaryItem"]}]}}, GridBoxAlignment -> {"Columns"
+                                                   -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> False, GridBoxItemSize
+                                                   -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, GridBoxSpacings
+                                                   -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}}, BaseStyle -> {ShowStringCharacters
+                                                   -> False, NumberMarks -> False, PrintPrecision -> 3, ShowSyntaxStyles
+                                                   -> False}]}}, GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete ->
+                                                   False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic
+                                                  }}}, BaselinePosition -> {1, 1}], True -> GridBox[{{PaneBox[ButtonBox[
+                                                  DynamicBox[FEPrivate`FrontEndResource["FEBitmaps", "SquareMinusIconMedium"
+                                                  ]], ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, Evaluator
+                                                   -> Automatic, Method -> "Preemptive"], Alignment -> {Center, Center},
+                                                   ImageSize -> Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"] /
+                                                   AbsoluteCurrentValue[Magnification]}]], GraphicsBox[GeometricTransformationBox[
+                                                  {{{FilledCurveBox[{{Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                                                  43.684000000000005`}, {36.558, 43.684000000000005`}, {36.558, 8.569}}
+                                                  ]}}]}, {FilledCurveBox[{{Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443,
+                                                   43.684000000000005`}, {59.053, 43.684000000000005`}, {59.053, 8.569}
+                                                  }]}}]}, {{FilledCurveBox[{{Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95,
+                                                   21.188000000000002`}, {55.487, 21.188000000000002`}, {55.487, 8.569}
+                                                  }]}}]}, {FilledCurveBox[{{Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025,
+                                                   21.188000000000002`}, {52.562, 21.188000000000002`}, {52.562, 8.569}
+                                                  }]}}]}, {FilledCurveBox[{{Line[{{49.636, 8.569}, {51.099000000000004`,
+                                                   8.569}, {51.099000000000004`, 21.188000000000002`}, {49.636, 21.188000000000002`
+                                                  }, {49.636, 8.569}}]}}]}, {FilledCurveBox[{{Line[{{46.709, 8.569}, {48.172000000000004`,
+                                                   8.569}, {48.172000000000004`, 21.188000000000002`}, {46.709, 21.188000000000002`
+                                                  }, {46.709, 8.569}}]}}]}, {FilledCurveBox[{{Line[{{43.783, 8.569}, {45.246,
+                                                   8.569}, {45.246, 21.188000000000002`}, {43.783, 21.188000000000002`},
+                                                   {43.783, 8.569}}]}}]}}, {FilledCurveBox[{{Line[{{40.947, 4.911}, {59.787000000000006`,
+                                                   4.911}, {59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 4.911
+                                                  }}]}}]}, {FilledCurveBox[{{Line[{{44.057, 31.675}, {56.678000000000004`,
+                                                   31.675}, {56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 31.675
+                                                  }}]}}]}, {FilledCurveBox[{{Line[{{44.057, 43.685}, {56.678000000000004`,
+                                                   43.685}, {56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 43.685
+                                                  }}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {ImageSize -> {Automatic, Dynamic[
+                                                  3.5 CurrentValue["FontCapHeight"] / AbsoluteCurrentValue[Magnification
+                                                  ]]}, PlotRange -> {{20, 80}, {0, 70}}, BaseStyle -> {CacheGraphics ->
+                                                   False}, ImageSize -> 30}], GridBox[{{RowBox[{TagBox["\"DestinationIPAddress: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox[RowBox[{"IPAddress",
+                                                   "[", "\"127.0.0.1\"", "]"}], "SummaryItem"]}]}, {RowBox[{TagBox["\"DestinationPort: \"",
+                                                   "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox["\"63781\"", "SummaryItem"
+                                                  ]}]}, {RowBox[{TagBox["\"SourceIPAddress: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox[RowBox[{"IPAddress", "[", "\"::500:5bde:ff17:6166\"",
+                                                   "]"}], "SummaryItem"]}]}, {RowBox[{TagBox["\"SourcePort: \"", "SummaryItemAnnotation"
+                                                  ], "\[InvisibleSpace]", TagBox["\"0\"", "SummaryItem"]}]}, {RowBox[{TagBox[
+                                                  "\"Protocol: \"", "SummaryItemAnnotation"], "\[InvisibleSpace]", TagBox[
+                                                  "\"ZMQ_PAIR\"", "SummaryItem"]}]}}, GridBoxAlignment -> {"Columns" ->
+                                                   {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> False, GridBoxItemSize
+                                                   -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, GridBoxSpacings
+                                                   -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}}, BaseStyle -> {ShowStringCharacters
+                                                   -> False, NumberMarks -> False, PrintPrecision -> 3, ShowSyntaxStyles
+                                                   -> False}]}}, GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete ->
+                                                   False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, "Rows" -> {{Automatic
+                                                  }}}, BaselinePosition -> {1, 1}]}, Dynamic[Typeset`open$$], ImageSize
+                                                   -> Automatic]}, "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                                                  SocketObject["ZMQ-3ef55c1d-4a9b-4c18-866b-a2c013f75fc7"], Selectable 
+                                                  -> False, Editable -> False, SelectWithContents -> True], "SummaryItem"
+                                                  ]}]}
+                                                ,
+                                                {
+                                                  RowBox[
+                                                    {
+                                                      TagBox["\"EvaluationCount: \"",
+                                                         "SummaryItemAnnotation"]
+                                                      ,
+                                                      "\[InvisibleSpace]"
+                                                        
+                                                      ,
+                                                      TagBox[
+                                                        DynamicBox[
+                                                          ToBoxes[
+                                                            If[TrueQ[
+                                                              ExternalEvaluate`Private`getSessionOpts["9d054758-6742-4dc1-bdf0-92cfab26dc91",
+                                                               "Exists"]],
+                                                              ExternalSessionObject[
+                                                                "9d054758-6742-4dc1-bdf0-92cfab26dc91"]["EvaluationCount"]
+                                                              ,
+                                                              None
+                                                            ]
+                                                            ,
+                                                            StandardForm
+                                                              
+                                                          ]
+                                                          ,
+                                                          TrackedSymbols
+                                                             :> {ExternalEvaluate`Private`$Links}
+                                                        ]
+                                                        ,
+                                                        "SummaryItem"
+                                                          
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                                ,
+                                                {
+                                                  RowBox[
+                                                    {
+                                                      TagBox["\"ProcessMemory: \"",
+                                                         "SummaryItemAnnotation"]
+                                                      ,
+                                                      "\[InvisibleSpace]"
+                                                        
+                                                      ,
+                                                      TagBox[
+                                                        DynamicBox[
+                                                          ToBoxes[
+                                                            If[TrueQ[
+                                                              ExternalEvaluate`Private`getSessionOpts["9d054758-6742-4dc1-bdf0-92cfab26dc91",
+                                                               "Exists"]],
+                                                              Refresh[
+                                                                ExternalSessionObject["9d054758-6742-4dc1-bdf0-92cfab26dc91"]["ProcessMemory"
+                                                                ], UpdateInterval -> 5]
+                                                              ,
+                                                              Missing[
+                                                                "NotAvailable"]
+                                                            ]
+                                                            ,
+                                                            StandardForm
+                                                              
+                                                          ]
+                                                          ,
+                                                          TrackedSymbols
+                                                             :> {ExternalEvaluate`Private`$Links}
+                                                        ]
+                                                        ,
+                                                        "SummaryItem"
+                                                          
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                                ,
+                                                {
+                                                  RowBox[
+                                                    {
+                                                      TagBox["\"ProcessThreads: \"",
+                                                         "SummaryItemAnnotation"]
+                                                      ,
+                                                      "\[InvisibleSpace]"
+                                                        
+                                                      ,
+                                                      TagBox[
+                                                        DynamicBox[
+                                                          ToBoxes[
+                                                            If[TrueQ[
+                                                              ExternalEvaluate`Private`getSessionOpts["9d054758-6742-4dc1-bdf0-92cfab26dc91",
+                                                               "Exists"]],
+                                                              Refresh[
+                                                                ExternalSessionObject["9d054758-6742-4dc1-bdf0-92cfab26dc91"]["ProcessThreads"
+                                                                ], UpdateInterval -> 5]
+                                                              ,
+                                                              Missing[
+                                                                "NotAvailable"]
+                                                            ]
+                                                            ,
+                                                            StandardForm
+                                                              
+                                                          ]
+                                                          ,
+                                                          TrackedSymbols
+                                                             :> {ExternalEvaluate`Private`$Links}
+                                                        ]
+                                                        ,
+                                                        "SummaryItem"
+                                                          
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                                ,
+                                                {
+                                                  RowBox[
+                                                    {
+                                                      TagBox["\"SessionTime: \"",
+                                                         "SummaryItemAnnotation"]
+                                                      ,
+                                                      "\[InvisibleSpace]"
+                                                        
+                                                      ,
+                                                      TagBox[
+                                                        DynamicBox[
+                                                          ToBoxes[
+                                                            If[TrueQ[
+                                                              ExternalEvaluate`Private`getSessionOpts["9d054758-6742-4dc1-bdf0-92cfab26dc91",
+                                                               "Exists"]],
+                                                              Refresh[
+                                                                ExternalSessionObject["9d054758-6742-4dc1-bdf0-92cfab26dc91"]["SessionTime"
+                                                                ], UpdateInterval -> 1]
+                                                              ,
+                                                              Missing[
+                                                                "NotAvailable"]
+                                                            ]
+                                                            ,
+                                                            StandardForm
+                                                              
+                                                          ]
+                                                          ,
+                                                          TrackedSymbols
+                                                             :> {ExternalEvaluate`Private`$Links}
+                                                        ]
+                                                        ,
+                                                        "SummaryItem"
+                                                          
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                              ,
+                                              GridBoxAlignment -> {"Columns"
+                                                 -> {{Left}}, "Rows" -> {{Automatic}}}
+                                              ,
+                                              AutoDelete -> False
+                                              ,
+                                              GridBoxItemSize -> {"Columns"
+                                                 -> {{Automatic}}, "Rows" -> {{Automatic}}}
+                                              ,
+                                              GridBoxSpacings -> {"Columns"
+                                                 -> {{2}}, "Rows" -> {{Automatic}}}
+                                              ,
+                                              BaseStyle -> {ShowStringCharacters
+                                                 -> False, NumberMarks -> False, PrintPrecision -> 3, ShowSyntaxStyles
+                                                 -> False}
+                                            ]
+                                          }
+                                        }
+                                        ,
+                                        GridBoxAlignment -> {"Rows" ->
+                                           {{Top}}}
+                                        ,
+                                        AutoDelete -> False
+                                        ,
+                                        GridBoxItemSize -> {"Columns"
+                                           -> {{Automatic}}, "Rows" -> {{Automatic}}}
+                                        ,
+                                        BaselinePosition -> {1, 1}
+                                      ]
+                                  }
+                                  ,
+                                  Dynamic[Typeset`open$$]
+                                  ,
+                                  ImageSize -> Automatic
+                                ]
+                              }
+                              ,
+                              "SummaryPanel"
+                            ]
+                            ,
+                            DynamicModuleValues :> {}
+                          ]
+                          ,
+                          "]"
+                        }
+                      ]
+                      ,
+                      ExternalSessionObject["9d054758-6742-4dc1-bdf0-92cfab26dc91"
+                        ]
+                      ,
+                      Editable -> False
+                      ,
+                      SelectWithContents -> True
+                      ,
+                      Selectable -> False
+                    ]
+                  ]
+                  ,
+                  "Output"
+                  ,
+                  CellChangeTimes -> {3.834825666132516*^9, 3.846040782326826*^9,
+                     3.8460410050460367`*^9, 3.8460417800745296`*^9, 3.84604188615975*^9,
+                     {3.84604207782257*^9, 3.846042090548864*^9}, 3.846042311852193*^9, 3.846158308474115*^9,
+                     3.8461667215366983`*^9, 3.846407988043374*^9, 3.84640814915168*^9, 3.846408238546768*^9
+                    }
+                  ,
+                  CellLabel -> "Out[5]="
+                  ,
+                  ExpressionUUID -> "e620fb46-ca28-4cc2-9a58-49a749a12856"
+                    
+                ]
+              }
+              ,
+              Open
+            ]
+          ]
+          ,
+          Cell[BoxData[RowBox[{RowBox[{"TestExpr", "[", RowBox[{"expr_",
+             ",", " ", RowBox[{"verbose_", ":", "False"}], ",", " ", RowBox[{"tol_",
+             ":", "1*^-8"}]}], "]"}], ":=", RowBox[{"Module", "[", RowBox[{RowBox[
+            {"{", RowBox[{"exprPy", ",", "resM", ",", "resP", ",", " ", "valid"}],
+             "}"}], ",", "\[IndentingNewLine]", RowBox[{"(*", " ", RowBox[{"Function",
+             " ", "that", " ", "compares", " ", "the", " ", "Mathematica", " ", "result",
+             " ", "to", " ", "the", " ", "python", " ", "result"}], " ", "*)"}], 
+            "\[IndentingNewLine]", RowBox[{RowBox[{"exprPy", "=", RowBox[{"ToPython",
+             "[", RowBox[{"expr", ",", RowBox[{"Copy", "\[Rule]", "False"}]}], "]"
+            }]}], ";", "\[IndentingNewLine]", RowBox[{"(*", " ", RowBox[{"evaluate",
+             " ", "the", " ", "expressions", " ", "in", " ", "Mathematica", " ", 
+            "and", " ", "in", " ", "python"}], " ", "*)"}], "\[IndentingNewLine]",
+             RowBox[{"resM", "=", RowBox[{"Normal", "[", RowBox[{"expr", "/.", "vals"
+            }], "]"}]}], ";", "\[IndentingNewLine]", "\[IndentingNewLine]", RowBox[
+            {"If", "[", RowBox[{RowBox[{"ArrayQ", "[", "resM", "]"}], ",", "\[IndentingNewLine]",
+             RowBox[{"resP", "=", RowBox[{"N", "@", RowBox[{"ExternalEvaluate", "[",
+             RowBox[{"session", ",", RowBox[{"exprPy", "<>", "\"\<.tolist()\>\""}
+            ]}], "]"}]}]}], "\[IndentingNewLine]", ",", RowBox[{"(*", "else", "*)"
+            }], "\[IndentingNewLine]", RowBox[{"resP", "=", RowBox[{"N", "@", RowBox[
+            {"ExternalEvaluate", "[", RowBox[{"session", ",", "exprPy"}], "]"}]}]
+            }]}], "\[IndentingNewLine]", "]"}], ";", "\[IndentingNewLine]", RowBox[
+            {"valid", "=", RowBox[{RowBox[{"Norm", "[", RowBox[{"resM", "-", "resP"
+            }], "]"}], "<", RowBox[{"tol", "+", RowBox[{"tol", "*", RowBox[{"Mean",
+             "[", RowBox[{"Norm", "/@", RowBox[{"{", RowBox[{"resM", ",", "resP"}
+            ], "}"}]}], "]"}]}]}]}]}], ";", "\[IndentingNewLine]", "\[IndentingNewLine]",
+             RowBox[{"If", "[", RowBox[{"verbose", ",", RowBox[{"Print", "@", RowBox[
+            {"StringForm", "[", RowBox[{"\"\<`` =?= ``\>\"", ",", " ", "resM", ",",
+             " ", "resP"}], "]"}]}]}], "]"}], ";", "\[IndentingNewLine]", RowBox[
+            {"If", "[", RowBox[{RowBox[{"valid", "=!=", "True"}], ",", "\[IndentingNewLine]",
+             RowBox[{"Print", "@", RowBox[{"StringForm", "[", RowBox[{"\"\<Error:\\nMathematica: ``\\nPythonForm: ``\\n`` != `` (diff: ``)\>\"",
+             ",", "\[IndentingNewLine]", RowBox[{"InputForm", "@", "expr"}], ",",
+             "exprPy", ",", "resM", ",", "resP", ",", RowBox[{"Norm", "[", RowBox[
+            {"resM", "-", "resP"}], "]"}]}], "]"}]}]}], "\[IndentingNewLine]", "]"
+            }], ";"}]}], "\[IndentingNewLine]", "]"}]}]], "Input", CellChangeTimes
+             -> {{3.8170417020811777`*^9, 3.81704172657474*^9}, {3.81704179280335*^9,
+             3.817041840489778*^9}, {3.817041927575897*^9, 3.817042036063344*^9},
+             {3.8170421879989634`*^9, 3.817042226019485*^9}, {3.817042299961542*^9,
+             3.817042425907525*^9}, {3.8171187981847067`*^9, 3.817118837881874*^9
+            }, {3.817118869098439*^9, 3.817118901147331*^9}, {3.817118980087762*^9,
+             3.81711925677897*^9}, {3.81711928731602*^9, 3.817119290162525*^9}, {
+            3.8171196009707813`*^9, 3.8171196235745583`*^9}, {3.817133292637014*^9,
+             3.817133292955245*^9}, {3.8172200224753237`*^9, 3.817220038170822*^9
+            }, {3.8172201143851852`*^9, 3.817220171218865*^9}, {3.8172202219502983`*^9,
+             3.817220222379529*^9}, {3.817220443941942*^9, 3.8172204825096703`*^9
+            }, {3.817220514090167*^9, 3.817220515003347*^9}, {3.8348256851524878`*^9,
+             3.8348256887404423`*^9}, {3.846042112354926*^9, 3.846042137622614*^9
+            }}, CellLabel -> "In[10]:=", ExpressionUUID -> "1daf2eb3-6166-48ed-992f-1473b56947a1"
+            ]
+        }
+        ,
+        Open
+      ]
+    ]
+    ,
+    Cell[CellGroupData[{Cell["Test cases", "Section", CellChangeTimes
+       -> {{3.846042058634193*^9, 3.8460420644426203`*^9}}, ExpressionUUID 
+      -> "a27a99f9-bd12-46d4-8624-85cc4f3e3bb5"], Cell[CellGroupData[{Cell[
+      "Test numeric examples", "Subsection", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.817020691587697*^9, 3.817020708510957*^9},
+       {3.817041939215971*^9, 3.817041941599523*^9}, {3.8170421343013906`*^9,
+       3.817042142368922*^9}, {3.8170422708990498`*^9, 3.8170422957666273`*^9
+      }, {3.817120307551271*^9, 3.817120316935302*^9}, {3.817273522417403*^9,
+       3.817273542125928*^9}, {3.817273580569841*^9, 3.817273583701936*^9},
+       {3.846041902853119*^9, 3.846041924803459*^9}}, ExpressionUUID -> "5185dd86-dec4-4c26-8e48-124321882ccc"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", "2", "]"}]], "Input", CellChangeTimes
+       -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020708510957*^9}, {3.817041939215971*^9, 3.817041941599523*^9},
+       {3.8170421343013906`*^9, 3.817042142368922*^9}, {3.8170422708990498`*^9,
+       3.8170422957666273`*^9}, {3.817120307551271*^9, 3.817120316935302*^9
+      }, {3.817273522417403*^9, 3.817273542125928*^9}, {3.817273580569841*^9,
+       3.817273583701936*^9}, {3.846041902853119*^9, 3.846041922919067*^9}},
+       CellLabel -> "In[11]:=", ExpressionUUID -> "d2ab5645-70dd-4a4c-a916-861a7f41c40f"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"1", "/", "3"}], "]"
+      }]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9,
+       3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9
+      }, {3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9,
+       3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9},
+       {3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9,
+       3.846041908793754*^9}}, CellLabel -> "In[12]:=", ExpressionUUID -> "bf998445-7f53-4e06-aa2b-bbedde1dd042"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"1.", "/", "3"}], "]"
+      }]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9,
+       3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9
+      }, {3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9,
+       3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9},
+       {3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9,
+       3.846041911460279*^9}}, CellLabel -> "In[13]:=", ExpressionUUID -> "ad674aef-74e7-4220-8935-283e9c43e016"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", "2.31", "]"}]], "Input", CellChangeTimes
+       -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020708510957*^9}, {3.817041939215971*^9, 3.817041941599523*^9},
+       {3.8170421343013906`*^9, 3.817042142368922*^9}, {3.8170422708990498`*^9,
+       3.8170422957666273`*^9}, {3.817120307551271*^9, 3.817120316935302*^9
+      }, {3.817273522417403*^9, 3.817273542125928*^9}, {3.817273580569841*^9,
+       3.817273583701936*^9}, {3.846041902853119*^9, 3.846041912381846*^9}},
+       CellLabel -> "In[14]:=", ExpressionUUID -> "891d4fba-9677-40a3-aa36-ac911d861410"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"2.31", "+", RowBox[
+      {"5.3", "I"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.817020691587697*^9, 3.817020708510957*^9},
+       {3.817041939215971*^9, 3.817041941599523*^9}, {3.8170421343013906`*^9,
+       3.817042142368922*^9}, {3.8170422708990498`*^9, 3.8170422957666273`*^9
+      }, {3.817120307551271*^9, 3.817120316935302*^9}, {3.817273522417403*^9,
+       3.817273542125928*^9}, {3.817273580569841*^9, 3.817273583701936*^9},
+       {3.846041902853119*^9, 3.8460419129741993`*^9}}, CellLabel -> "In[15]:=",
+       ExpressionUUID -> "d7af6c11-af2c-467a-a27e-4d20c06250f9"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", "1*^30", "]"}]], "Input", CellChangeTimes ->
+       {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020708510957*^9}, {3.817041939215971*^9, 3.817041941599523*^9},
+       {3.8170421343013906`*^9, 3.817042142368922*^9}, {3.8170422708990498`*^9,
+       3.8170422957666273`*^9}, {3.817120307551271*^9, 3.817120316935302*^9
+      }, {3.817273522417403*^9, 3.817273542125928*^9}, {3.817273580569841*^9,
+       3.817273583701936*^9}, {3.846041902853119*^9, 3.846041913542753*^9}},
+       CellLabel -> "In[16]:=", ExpressionUUID -> "9da2859f-5de4-41ed-834e-b6411e93e3c8"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", "1*^-30", "]"}]], "Input", CellChangeTimes
+       -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020708510957*^9}, {3.817041939215971*^9, 3.817041941599523*^9},
+       {3.8170421343013906`*^9, 3.817042142368922*^9}, {3.8170422708990498`*^9,
+       3.8170422957666273`*^9}, {3.817120307551271*^9, 3.817120316935302*^9
+      }, {3.817273522417403*^9, 3.817273542125928*^9}, {3.817273580569841*^9,
+       3.817273583701936*^9}, {3.846041902853119*^9, 3.846041914105044*^9}},
+       CellLabel -> "In[17]:=", ExpressionUUID -> "6967dc5d-a3ee-456d-8e2b-c49ae6fd06df"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"N", "[", RowBox[{"Pi",
+       ",", "40"}], "]"}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.817020691587697*^9, 3.817020708510957*^9},
+       {3.817041939215971*^9, 3.817041941599523*^9}, {3.8170421343013906`*^9,
+       3.817042142368922*^9}, {3.8170422708990498`*^9, 3.8170422957666273`*^9
+      }, {3.817120307551271*^9, 3.817120316935302*^9}, {3.817273522417403*^9,
+       3.817273542125928*^9}, {3.817273580569841*^9, 3.817273583701936*^9},
+       {3.846041902853119*^9, 3.846041914651318*^9}}, CellLabel -> "In[18]:=",
+       ExpressionUUID -> "b724c4b6-a2eb-4f9d-816c-3b5afb62e3f1"]}, Open]], 
+      Cell[CellGroupData[{Cell["Test simple expressions", "Subsection", CellChangeTimes
+       -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.8170418609071417`*^9,
+       3.817041872218865*^9}, 3.817042250551552*^9, {3.817120284841795*^9, 
+      3.817120284977632*^9}, {3.817273573444448*^9, 3.8172735792254133`*^9},
+       {3.8243812261167088`*^9, 3.824381227200451*^9}, {3.824385042461767*^9,
+       3.82438504484193*^9}, {3.8460407883889914`*^9, 3.846040796525504*^9},
+       {3.846041929532474*^9, 3.846041932973956*^9}}, ExpressionUUID -> "740923fd-dd9e-45ca-b781-36fcddb044a7"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"a", "+", "b"}], "]"
+      }]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9,
+       {3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9,
+       3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9
+      }, {3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9,
+       3.846040796525504*^9}, 3.846041929532474*^9, 3.846041973392763*^9}, 
+      CellLabel -> "In[19]:=", ExpressionUUID -> "622a3868-cc93-4e9f-9244-dd90a3b0e230"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"a", "+", "b", "+", 
+      "d"}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9,
+       {3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9,
+       3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9
+      }, {3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9,
+       3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
+      3.846041973899994*^9}}, CellLabel -> "In[20]:=", ExpressionUUID -> "d01a1f82-0634-497a-bd28-045fa1359270"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"a", "*", "b"}], "]"
+      }]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9,
+       {3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9,
+       3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9
+      }, {3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9,
+       3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
+      3.846041974404408*^9}}, CellLabel -> "In[21]:=", ExpressionUUID -> "d0960264-a1eb-4839-825b-0c85d421789c"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"a", "*", "b", "*", 
+      "c"}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9,
+       {3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9,
+       3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9
+      }, {3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9,
+       3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
+      3.846041974950733*^9}}, CellLabel -> "In[22]:=", ExpressionUUID -> "43e88e09-b2cb-4b40-9ef3-257eb977fb9c"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"a", "/", "b"}], "]"
+      }]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9,
+       {3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9,
+       3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9
+      }, {3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9,
+       3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
+      3.846041975415821*^9}}, CellLabel -> "In[23]:=", ExpressionUUID -> "b7ce3257-a3a1-47e8-b3d8-3b4360a0a4a2"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{RowBox[{"(", RowBox[
+      {"a", "+", "b"}], ")"}], "/", RowBox[{"(", RowBox[{"d", "+", "e", "+",
+       "g"}], ")"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9
+      }, 3.817042250551552*^9, {3.817120284841795*^9, 3.817120284977632*^9},
+       {3.817273573444448*^9, 3.8172735792254133`*^9}, {3.8243812261167088`*^9,
+       3.824381227200451*^9}, {3.824385042461767*^9, 3.82438504484193*^9}, 
+      {3.8460407883889914`*^9, 3.846040796525504*^9}, 3.846041929532474*^9,
+       {3.846041973392763*^9, 3.846041976071169*^9}}, CellLabel -> "In[24]:=",
+       ExpressionUUID -> "8430173d-a223-44f9-8854-a777595d6f28"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{RowBox[{"(", RowBox[{"a", "+", "b"}],
+       ")"}], "^", RowBox[{"(", RowBox[{"d", "+", "e", "+", "g"}], ")"}]}],
+       "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9
+      }, {3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9,
+       {3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9,
+       3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9
+      }, {3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9,
+       3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
+      3.846041976569558*^9}}, CellLabel -> "In[25]:=", ExpressionUUID -> "6dac367c-012b-4f05-910e-5e1cdb6b9d36"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"Exp", "[", RowBox[{
+      "a", "+", "b"}], "]"}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9
+      }, 3.817042250551552*^9, {3.817120284841795*^9, 3.817120284977632*^9},
+       {3.817273573444448*^9, 3.8172735792254133`*^9}, {3.8243812261167088`*^9,
+       3.824381227200451*^9}, {3.824385042461767*^9, 3.82438504484193*^9}, 
+      {3.8460407883889914`*^9, 3.846040796525504*^9}, 3.846041929532474*^9,
+       {3.846041973392763*^9, 3.846041977947075*^9}}, CellLabel -> "In[26]:=",
+       ExpressionUUID -> "e89b6c2c-4333-4c40-b1b7-71690b6227c0"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{RowBox[{"Sin", "[", RowBox[{"(", RowBox[
+      {"a", "+", "b"}], ")"}], "]"}], "/", RowBox[{"Cos", "[", RowBox[{"d",
+       "+", "e"}], "]"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9
+      }, 3.817042250551552*^9, {3.817120284841795*^9, 3.817120284977632*^9},
+       {3.817273573444448*^9, 3.8172735792254133`*^9}, {3.8243812261167088`*^9,
+       3.824381227200451*^9}, {3.824385042461767*^9, 3.82438504484193*^9}, 
+      {3.8460407883889914`*^9, 3.846040796525504*^9}, 3.846041929532474*^9,
+       {3.846041973392763*^9, 3.846041978438273*^9}}, CellLabel -> "In[27]:=",
+       ExpressionUUID -> "e8909287-f2aa-46b1-82c2-11d3ae21304d"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{RowBox[{"Sin", "[", RowBox[{"(", RowBox[
+      {"a", "+", "b"}], ")"}], "]"}], "/", RowBox[{"Tanh", "[", RowBox[{"d",
+       "+", "e"}], "]"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9
+      }, 3.817042250551552*^9, {3.817120284841795*^9, 3.817120284977632*^9},
+       {3.817273573444448*^9, 3.8172735792254133`*^9}, {3.8243812261167088`*^9,
+       3.824381227200451*^9}, {3.824385042461767*^9, 3.82438504484193*^9}, 
+      {3.8460407883889914`*^9, 3.846040796525504*^9}, 3.846041929532474*^9,
+       {3.846041973392763*^9, 3.846041978892454*^9}}, CellLabel -> "In[28]:=",
+       ExpressionUUID -> "67fd3b61-19e7-4444-9c7b-8d4becc7480c"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{"\[Pi]", " ", RowBox[{"Cosh", "[", "a",
+       "]"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9
+      }, 3.817042250551552*^9, {3.817120284841795*^9, 3.817120284977632*^9},
+       {3.817273573444448*^9, 3.8172735792254133`*^9}, {3.8243812261167088`*^9,
+       3.824381227200451*^9}, {3.824385042461767*^9, 3.82438504484193*^9}, 
+      {3.8460407883889914`*^9, 3.846040796525504*^9}, 3.846041929532474*^9,
+       {3.846041973392763*^9, 3.8460419793917923`*^9}}, CellLabel -> "In[29]:=",
+       ExpressionUUID -> "fdef6874-99c9-4558-8fca-639ab5cd2100"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{"1", "/", RowBox[{"Sqrt", "[", "a", 
+      "]"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9, 
+      3.817007961051466*^9}, {3.8170418609071417`*^9, 3.817041872218865*^9},
+       3.817042250551552*^9, {3.817120284841795*^9, 3.817120284977632*^9}, 
+      {3.817273573444448*^9, 3.8172735792254133`*^9}, {3.8243812261167088`*^9,
+       3.824381227200451*^9}, {3.824385042461767*^9, 3.82438504484193*^9}, 
+      {3.8460407883889914`*^9, 3.846040796525504*^9}, 3.846041929532474*^9,
+       {3.846041973392763*^9, 3.846041979873971*^9}}, CellLabel -> "In[30]:=",
+       ExpressionUUID -> "dd120ca1-848e-423b-8132-8a4ad1af66b7"]}, Open]], 
+      Cell[CellGroupData[{Cell["Test more complex expression", "Subsection",
+       CellChangeTimes -> {{3.846158166621696*^9, 3.846158172465621*^9}}, ExpressionUUID
+       -> "f8397244-1ddc-4683-9ba2-1631f6f2ff53"], Cell[BoxData[RowBox[{RowBox[
+      {"xs", "=", RowBox[{"x", "/.", RowBox[{"Solve", "[", RowBox[{RowBox[{
+      RowBox[{RowBox[{"a", "*", RowBox[{"x", "^", "2"}]}], "-", RowBox[{"b",
+       "*", "x"}], "+", "c"}], "\[Equal]", "0"}], ",", "x"}], "]"}]}]}], ";"
+      }]], "Input", CellChangeTimes -> {{3.846158181269034*^9, 3.846158184218039*^9
+      }, {3.8461582922280684`*^9, 3.846158299353643*^9}, {3.846158415782278*^9,
+       3.846158482201703*^9}, {3.8461591530743628`*^9, 3.846159182503839*^9
+      }, {3.84616668901619*^9, 3.84616671474564*^9}}, CellLabel -> "In[31]:=",
+       ExpressionUUID -> "4a484416-8716-4c9a-a177-e23d82b841bf"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{"xs", "[", RowBox[{"[", "1", "]"}], 
+      "]"}], "]"}]], "Input", CellChangeTimes -> {{3.846158181269034*^9, 3.846158184218039*^9
+      }, {3.8461582922280684`*^9, 3.846158299353643*^9}, {3.846158415782278*^9,
+       3.846158482201703*^9}, {3.8461591530743628`*^9, 3.846159188526732*^9
+      }}, CellLabel -> "In[32]:=", ExpressionUUID -> "4124d2cf-9243-403b-88b8-8fc04ac56def"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"xs", "[", RowBox[{"[",
+       "2", "]"}], "]"}], "]"}]], "Input", CellChangeTimes -> {3.8461591911438313`*^9
+      }, CellLabel -> "In[33]:=", ExpressionUUID -> "05090169-8f98-4d80-a8c4-a624f7083a03"
+      ], Cell[BoxData[RowBox[{"TestExpr", "@", RowBox[{"Assuming", "[", RowBox[
+      {RowBox[{RowBox[{"a", ">", "0"}], "&&", RowBox[{"c", ">", "0"}]}], ",",
+       RowBox[{"Simplify", "@", RowBox[{"Norm", "@", RowBox[{"{", RowBox[{RowBox[
+      {"{", RowBox[{RowBox[{"Sin", "[", "a", "]"}], ",", RowBox[{"Sqrt", "[",
+       "c", "]"}]}], "}"}], ",", RowBox[{"{", RowBox[{"2", ",", RowBox[{"a",
+       "^", "2"}]}], "}"}]}], "}"}]}]}]}], "]"}]}]], "Input", CellChangeTimes
+       -> {{3.846408000340914*^9, 3.846408017120659*^9}, {3.84640816301118*^9,
+       3.846408179006751*^9}}, CellLabel -> "In[34]:=", ExpressionUUID -> "47d0e7b8-7fc1-41ab-a340-d7245957e301"
+      ]}, Open]], Cell[CellGroupData[{Cell["Test constants", "Subsection", 
+      CellChangeTimes -> {{3.817219734532898*^9, 3.817219757613577*^9}, {3.81727358772644*^9,
+       3.8172735887082853`*^9}, {3.846041981098611*^9, 3.8460419985237017`*^9
+      }}, ExpressionUUID -> "8b3d5e80-8e20-438b-87ee-ceea90da1c2e"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", "Pi", "]"}]], "Input", CellChangeTimes -> {{
+      3.817219734532898*^9, 3.817219757613577*^9}, {3.81727358772644*^9, 3.8172735887082853`*^9
+      }, {3.846041981098611*^9, 3.846041982203734*^9}}, CellLabel -> "In[35]:=",
+       ExpressionUUID -> "37d2d871-953e-4c23-bc44-f83a3b622304"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", "E", "]"}]], "Input", CellChangeTimes -> {{3.817219734532898*^9,
+       3.817219757613577*^9}, {3.81727358772644*^9, 3.8172735887082853`*^9},
+       {3.846041981098611*^9, 3.846041982203734*^9}}, CellLabel -> "In[36]:=",
+       ExpressionUUID -> "8f765bef-c3b4-4a72-889e-faed0af5e750"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{"N", "@", RowBox[{"Sqrt", "[", "2", 
+      "]"}]}], "]"}]], "Input", CellChangeTimes -> {{3.817219734532898*^9, 
+      3.817219757613577*^9}, {3.81727358772644*^9, 3.8172735887082853`*^9},
+       {3.846041981098611*^9, 3.846041983003277*^9}}, CellLabel -> "In[37]:=",
+       ExpressionUUID -> "d58c4ae4-2ee3-4f60-8649-e005867fbd14"], Cell[BoxData[
+      RowBox[{"TestExpr", "[", RowBox[{"N", "@", "Pi"}], "]"}]], "Input", CellChangeTimes
+       -> {{3.817219734532898*^9, 3.817219757613577*^9}, {3.81727358772644*^9,
+       3.8172735887082853`*^9}, {3.846041981098611*^9, 3.846041983504922*^9
+      }}, CellLabel -> "In[38]:=", ExpressionUUID -> "beed9989-7b46-45f6-b92e-d9534e983cae"
+      ]}, Open]], Cell[CellGroupData[{Cell["Test array handling", "Subsection",
+       CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020703952483*^9}, {3.817042042716785*^9, 3.817042043976235*^9},
+       {3.81711939281493*^9, 3.817119394171856*^9}, {3.817133214478402*^9, 
+      3.817133216574778*^9}, {3.817220529995721*^9, 3.8172205307949047`*^9},
+       {3.817273590716207*^9, 3.817273591432549*^9}, {3.846041987064098*^9,
+       3.846042008138753*^9}}, ExpressionUUID -> "292185a9-2fb5-4cee-ba04-979e10b4d536"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"{", RowBox[{"a", ",",
+       "b", ",", "c"}], "}"}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.817020691587697*^9, 3.817020703952483*^9},
+       {3.817042042716785*^9, 3.817042043976235*^9}, {3.81711939281493*^9, 
+      3.817119394171856*^9}, {3.817133214478402*^9, 3.817133216574778*^9}, 
+      {3.817220529995721*^9, 3.8172205307949047`*^9}, {3.817273590716207*^9,
+       3.817273591432549*^9}, {3.846041987064098*^9, 3.8460419875670156`*^9
+      }}, CellLabel -> "In[39]:=", ExpressionUUID -> "9325edd7-eacf-45d9-a0aa-6cb7fc2b9707"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"{", RowBox[{"{", RowBox[
+      {"1", ",", "2", ",", "3"}], "}"}], "}"}], "]"}]], "Input", CellChangeTimes
+       -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020703952483*^9}, {3.817042042716785*^9, 3.817042043976235*^9},
+       {3.81711939281493*^9, 3.817119394171856*^9}, {3.817133214478402*^9, 
+      3.817133216574778*^9}, {3.817220529995721*^9, 3.8172205307949047`*^9},
+       {3.817273590716207*^9, 3.817273591432549*^9}, {3.846041987064098*^9,
+       3.846041988161628*^9}}, CellLabel -> "In[40]:=", ExpressionUUID -> "8c4b586c-c3d0-42ee-a1e6-2e373492ac18"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"Cos", "[", RowBox[{
+      "{", RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], "]"}]], "Input",
+       CellChangeTimes -> {{3.817007935108295*^9, 3.817007961051466*^9}, {3.817020691587697*^9,
+       3.817020703952483*^9}, {3.817042042716785*^9, 3.817042043976235*^9},
+       {3.81711939281493*^9, 3.817119394171856*^9}, {3.817133214478402*^9, 
+      3.817133216574778*^9}, {3.817220529995721*^9, 3.8172205307949047`*^9},
+       {3.817273590716207*^9, 3.817273591432549*^9}, {3.846041987064098*^9,
+       3.846041988725069*^9}}, CellLabel -> "In[41]:=", ExpressionUUID -> "55454dae-6e1e-4815-94e6-523a2247c161"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"NumericArray", "[",
+       RowBox[{RowBox[{"{", RowBox[{RowBox[{"{", RowBox[{"1", ",", "2"}], "}"
+      }], ",", RowBox[{"{", RowBox[{"3", ",", "4"}], "}"}]}], "}"}], ",", "\"\<Integer32\>\""
+      }], "]"}], "]"}]], "Input", CellChangeTimes -> {{3.817007935108295*^9,
+       3.817007961051466*^9}, {3.817020691587697*^9, 3.817020703952483*^9},
+       {3.817042042716785*^9, 3.817042043976235*^9}, {3.81711939281493*^9, 
+      3.817119394171856*^9}, {3.817133214478402*^9, 3.817133216574778*^9}, 
+      {3.817220529995721*^9, 3.8172205307949047`*^9}, {3.817273590716207*^9,
+       3.817273591432549*^9}, {3.846041987064098*^9, 3.846041988725069*^9}},
+       CellLabel -> "In[42]:=", ExpressionUUID -> "80f5a18a-2e1c-43d0-9b42-8e79c2facab6"
+      ]}, Open]], Cell[CellGroupData[{Cell["Test special functions of one argument",
+       "Subsection", CellChangeTimes -> {{3.817119378001226*^9, 3.817119478821705*^9
+      }, {3.817119841126937*^9, 3.8171199085150433`*^9}, {3.817120294809811*^9,
+       3.8171202949819508`*^9}, {3.817273244838635*^9, 3.817273261133836*^9
+      }, {3.817273561872357*^9, 3.817273563524414*^9}, {3.8460419904284897`*^9,
+       3.846042015638241*^9}}, ExpressionUUID -> "9004b91b-2ef8-48dc-bf1f-39d9648a9831"
+      ], Cell[BoxData[RowBox[{RowBox[{"Map", "[", RowBox[{RowBox[{RowBox[{"TestExpr",
+       "[", RowBox[{"#", "[", RowBox[{"a", "-", "c"}], "]"}], "]"}], "&"}],
+       ",", RowBox[{"{", RowBox[{"Log10", ",", "Sqrt", ",", "Exp", ",", "Sin",
+       ",", "Cos", ",", "Tan", ",", "Csc", ",", "Sec", ",", "Cot", ",", "Sinh",
+       ",", "Cosh", ",", "Tanh", ",", "Csch", ",", "Sech", ",", "Coth", ",",
+       " ", "Gamma"}], "}"}]}], "]"}], ";"}]], "Input", CellChangeTimes -> 
+      {{3.817119378001226*^9, 3.817119478821705*^9}, {3.817119841126937*^9,
+       3.8171199085150433`*^9}, {3.817120294809811*^9, 3.8171202949819508`*^9
+      }, {3.817273244838635*^9, 3.817273261133836*^9}, {3.817273561872357*^9,
+       3.817273563524414*^9}, 3.8460419904284897`*^9}, CellLabel -> "In[43]:=",
+       ExpressionUUID -> "0c207f89-6be0-4cb7-b228-331ba7e2e930"]}, Open]], 
+      Cell[CellGroupData[{Cell["Test special functions of two arguments", "Subsection",
+       CellChangeTimes -> {{3.817219195028184*^9, 3.817219220967013*^9}, {3.817219323326161*^9,
+       3.8172193325693407`*^9}, {3.817273233785985*^9, 3.817273259608906*^9
+      }, 3.846041991510054*^9, {3.846042023129198*^9, 3.846042032414493*^9}
+      }, ExpressionUUID -> "07df250e-87b1-4228-9a21-d011319228fc"], Cell[BoxData[
+      RowBox[{RowBox[{"Map", "[", RowBox[{RowBox[{RowBox[{"TestExpr", "[", 
+      RowBox[{"#", "[", RowBox[{"a", ",", "b"}], "]"}], "]"}], "&"}], ",", 
+      RowBox[{"{", RowBox[{"Gamma", ",", "BesselI", ",", "BesselJ", ",", "BesselK",
+       ",", "BesselY"}], "}"}]}], "]"}], ";"}]], "Input", CellChangeTimes ->
+       {{3.817219195028184*^9, 3.817219220967013*^9}, {3.817219323326161*^9,
+       3.8172193325693407`*^9}, {3.817273233785985*^9, 3.817273259608906*^9
+      }, 3.846041991510054*^9}, CellLabel -> "In[44]:=", ExpressionUUID -> 
+      "9662f5ee-5f1f-4b30-aa68-fe818f5045fd"]}, Open]], Cell[CellGroupData[
+      {Cell["Test special functions for more complicated cases", "Subsection",
+       CellChangeTimes -> {{3.8172735000772457`*^9, 3.817273508216394*^9}, 
+      {3.846041992808167*^9, 3.846041993470435*^9}, {3.846042027978241*^9, 
+      3.846042030735072*^9}}, ExpressionUUID -> "4e89ff29-6ed5-4222-b155-669840286e53"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"Arg", "[", RowBox[{
+      "a", "+", RowBox[{"b", " ", "I"}]}], "]"}], "]"}]], "Input", CellChangeTimes
+       -> {{3.8172735000772457`*^9, 3.817273508216394*^9}, {3.846041992808167*^9,
+       3.846041993470435*^9}}, CellLabel -> "In[45]:=", ExpressionUUID -> "66c391ad-09e8-4146-b5f4-2fbcc12aa3d5"
+      ], Cell[BoxData[RowBox[{"TestExpr", "[", RowBox[{"SphericalHarmonicY",
+       "[", RowBox[{"b", ",", "a", ",", "c", ",", "d"}], "]"}], "]"}]], "Input",
+       CellChangeTimes -> {{3.8172735000772457`*^9, 3.817273508216394*^9}, 
+      3.846041992808167*^9}, CellLabel -> "In[46]:=", ExpressionUUID -> "01377ee4-a30f-447b-8174-2568e047951d"
+      ]}, Open]]}, Open]]
+  }
+  ,
+  WindowSize -> {808, 701}
+  ,
+  WindowMargins -> {{172, Automatic}, {Automatic, 144}}
+  ,
+  FrontEndVersion -> "12.1 for Mac OS X x86 (64-bit) (March 13, 2020)"
     
-    TemplateBox[{
-      PaneSelectorBox[{False -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource[
-               "FEBitmaps", "SquarePlusIconMedium"]], 
-              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 3.5 CurrentValue["FontCapHeight"]/
-                AbsoluteCurrentValue[Magnification]}]], 
-            GraphicsBox[{{
-               Hue[0.5766283524904214, 0.6682027649769585, 0.651], 
-               EdgeForm[None], 
-               
-               FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
-                 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {
-                 0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{58, 120}, {
-                 60, 120}, {62, 118}, {62, 115}, {62, 112}, {60, 110}, {58, 
-                 110}, {55, 110}, {53, 112}, {53, 115}, {53, 118}, {55, 
-                 120}, {58, 120}}, {{72, 128}, {44, 128}, {46, 116}, {46, 
-                 116}, {46, 104}, {73, 104}, {73, 100}, {36, 100}, {36, 
-                 100}, {18, 102}, {18, 74}, {18, 45}, {33, 46}, {33, 46}, {43,
-                  46}, {43, 59}, {43, 59}, {42, 75}, {58, 75}, {85, 75}, {85, 
-                 75}, {99, 75}, {99, 89}, {99, 114}, {99, 114}, {102, 128}, {
-                 72, 128}}}]}, {
-               Hue[0.1164, 0.745, 0.99], 
-               EdgeForm[None], 
-               
-               FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
-                 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {
-                 0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{88, 27}, {85,
-                  27}, {83, 29}, {83, 32}, {83, 34}, {85, 37}, {88, 37}, {91, 
-                 37}, {93, 34}, {93, 32}, {93, 29}, {91, 27}, {88, 27}}, {{73,
-                  18}, {101, 18}, {99, 31}, {99, 31}, {99, 43}, {73, 43}, {73,
-                  47}, {110, 47}, {110, 47}, {128, 45}, {128, 73}, {128, 
-                 102}, {112, 101}, {112, 101}, {103, 101}, {103, 87}, {103, 
-                 87}, {104, 72}, {88, 72}, {61, 72}, {61, 72}, {46, 72}, {46, 
-                 57}, {46, 33}, {46, 33}, {44, 18}, {73, 18}}}]}}, {
-             ImageSize -> {Automatic, 
-                Dynamic[3.5 CurrentValue["FontCapHeight"]]}, 
-              ImageSize -> {Automatic, 
-                Dynamic[3.5 CurrentValue["FontCapHeight"]]}}], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"System: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"Python\"", "SummaryItem"]}], 
-               RowBox[{
-                 TagBox["\"Version: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"3.7.9\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"9d054758-6742-4dc1-bdf0-92cfab26dc91\"", "SummaryItem"]}],
-                "\[SpanFromLeft]"}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-          GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete -> False, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}], True -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource[
-               "FEBitmaps", "SquareMinusIconMedium"]], 
-              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 3.5 CurrentValue["FontCapHeight"]/
-                AbsoluteCurrentValue[Magnification]}]], 
-            GraphicsBox[{{
-               Hue[0.5766283524904214, 0.6682027649769585, 0.651], 
-               EdgeForm[None], 
-               
-               FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
-                 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {
-                 0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{58, 120}, {
-                 60, 120}, {62, 118}, {62, 115}, {62, 112}, {60, 110}, {58, 
-                 110}, {55, 110}, {53, 112}, {53, 115}, {53, 118}, {55, 
-                 120}, {58, 120}}, {{72, 128}, {44, 128}, {46, 116}, {46, 
-                 116}, {46, 104}, {73, 104}, {73, 100}, {36, 100}, {36, 
-                 100}, {18, 102}, {18, 74}, {18, 45}, {33, 46}, {33, 46}, {43,
-                  46}, {43, 59}, {43, 59}, {42, 75}, {58, 75}, {85, 75}, {85, 
-                 75}, {99, 75}, {99, 89}, {99, 114}, {99, 114}, {102, 128}, {
-                 72, 128}}}]}, {
-               Hue[0.1164, 0.745, 0.99], 
-               EdgeForm[None], 
-               
-               FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
-                 3}}, {{1, 4, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {
-                 0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{88, 27}, {85,
-                  27}, {83, 29}, {83, 32}, {83, 34}, {85, 37}, {88, 37}, {91, 
-                 37}, {93, 34}, {93, 32}, {93, 29}, {91, 27}, {88, 27}}, {{73,
-                  18}, {101, 18}, {99, 31}, {99, 31}, {99, 43}, {73, 43}, {73,
-                  47}, {110, 47}, {110, 47}, {128, 45}, {128, 73}, {128, 
-                 102}, {112, 101}, {112, 101}, {103, 101}, {103, 87}, {103, 
-                 87}, {104, 72}, {88, 72}, {61, 72}, {61, 72}, {46, 72}, {46, 
-                 57}, {46, 33}, {46, 33}, {44, 18}, {73, 18}}}]}}, {
-             ImageSize -> {Automatic, 
-                Dynamic[3.5 CurrentValue["FontCapHeight"]]}, 
-              ImageSize -> {Automatic, 
-                Dynamic[3.5 CurrentValue["FontCapHeight"]]}}], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"System: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"Python\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"Version: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"3.7.9\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"9d054758-6742-4dc1-bdf0-92cfab26dc91\"", 
-                  "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"Active: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  DynamicBox[
-                   ToBoxes[
-                    If[
-                    TrueQ[
-                    ExternalEvaluate`Private`getSessionOpts[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91", "Exists"]], 
-                    ExternalSessionObject[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91"]["Active"], False],
-                     StandardForm], 
-                   TrackedSymbols :> {ExternalEvaluate`Private`$Links}], 
-                  "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"Executable: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"/opt/local/bin/python3\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"9d054758-6742-4dc1-bdf0-92cfab26dc91\"", 
-                  "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"Process: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  InterpretationBox[
-                   RowBox[{
-                    TagBox["ProcessObject", "SummaryHead"], "[", 
-                    
-                    DynamicModuleBox[{
-                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-                    TemplateBox[{
-                    PaneSelectorBox[{False -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SquarePlusIconMedium"]], 
-                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
-                    None, Evaluator -> Automatic, Method -> "Preemptive"], 
-                    Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"]/
-                    AbsoluteCurrentValue[Magnification]}]], 
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"Program: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"python3.8\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"PID: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["85527", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {
-                    ShowStringCharacters -> False, NumberMarks -> False, 
-                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-                    GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}], True -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SquareMinusIconMedium"]], 
-                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
-                    None, Evaluator -> Automatic, Method -> "Preemptive"], 
-                    Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"]/
-                    AbsoluteCurrentValue[Magnification]}]], 
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"Program: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"python3.8\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"PID: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["85527", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Parent PID: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["85524", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"User: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"dzwicker\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Path: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"/opt/local/Library/Frameworks/Python.framework/\
-Versions/3.8/Resources/Python.app/Contents/MacOS/Python\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Memory:\"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    
-                    TemplateBox[{"20.508672`", "\"MB\"", "megabytes", 
-                    "\"Megabytes\""}, "Quantity", SyntaxForm -> Mod], 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Threads: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["3", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Start Time: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    TemplateBox[{
-                    RowBox[{"\"Sat 20 Nov 2021 15:43:58\"", 
-                    StyleBox[
-                    RowBox[{"\"GMT+\"", "\[InvisibleSpace]", 
-                    StyleBox[
-                    "1.`", NumberMarks -> False, StripOnInput -> False]}], 
-                    FontColor -> GrayLevel[0.5]]}], 
-                    RowBox[{"DateObject", "[", 
-                    RowBox[{
-                    RowBox[{"{", 
-                    
-                    RowBox[{"2021", ",", "11", ",", "20", ",", "15", ",", 
-                    "43", ",", "58.`"}], "}"}], ",", "\"Instant\"", ",", 
-                    "\"Gregorian\"", ",", "1.`"}], "]"}]}, "DateObject", 
-                    Editable -> False], "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"System Time: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    
-                    TemplateBox[{"0.1148549999999999988`5.", "\"s\"", 
-                    "seconds", "\"Seconds\""}, "Quantity", SyntaxForm -> Mod],
-                     "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"User Time: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    
-                    TemplateBox[{"0.2291410000000000113`5.", "\"s\"", 
-                    "seconds", "\"Seconds\""}, "Quantity", SyntaxForm -> Mod],
-                     "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Real Time: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    
-                    TemplateBox[{"0", "\"s\"", "seconds", "\"Seconds\""}, 
-                    "Quantity", SyntaxForm -> Mod], "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {
-                    ShowStringCharacters -> False, NumberMarks -> False, 
-                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-                    GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}]}, 
-                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
-                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
-                   ProcessObject[
-                    Association[
-                    "ManagedProcess" -> True, "UID" -> 0, "PID" -> 85527, 
-                    "PPID" -> 85524, "Program" -> "python3.8", "Path" -> 
-                    "/opt/local/Library/Frameworks/Python.framework/Versions/\
-3.8/bin/python3.8", "User" -> "dzwicker", "StartTime" -> 
-                    DateObject[{2021, 11, 20, 15, 43, 58.}, "Instant", 
-                    "Gregorian", 1.]]], Selectable -> False, Editable -> 
-                   False, SelectWithContents -> True], "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"ReturnType: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"Expression\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"Socket: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  InterpretationBox[
-                   RowBox[{
-                    TagBox["SocketObject", "SummaryHead"], "[", 
-                    
-                    DynamicModuleBox[{
-                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-                    TemplateBox[{
-                    PaneSelectorBox[{False -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SquarePlusIconMedium"]], 
-                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
-                    None, Evaluator -> Automatic, Method -> "Preemptive"], 
-                    Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"]/
-                    AbsoluteCurrentValue[Magnification]}]], 
-                    GraphicsBox[
-                    GeometricTransformationBox[{{{
-                    FilledCurveBox[{{
-                    
-                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
-                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
-                    36.558, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
-                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
-                    59.053, 8.569}}]}}]}, {{
-                    FilledCurveBox[{{
-                    
-                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
-                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
-                    55.487, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
-                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
-                    52.562, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
-                    51.099000000000004`, 21.188000000000002`}, {49.636, 
-                    21.188000000000002`}, {49.636, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
-                    48.172000000000004`, 21.188000000000002`}, {46.709, 
-                    21.188000000000002`}, {46.709, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
-                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
-                    43.783, 8.569}}]}}]}}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
-                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
-                    4.911}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
-                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
-                    31.675}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
-                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
-                    43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
-                    ImageSize -> {Automatic, 
-                    Dynamic[
-                    3.5 CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification]]}, PlotRange -> {{20, 80}, {0, 70}}, 
-                    BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
-                    
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"IPAddress: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"127.0.0.1\"", "SummaryItem"]}], 
-                    RowBox[{
-                    TagBox["\"Port: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"63781\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"ZMQ-3ef55c1d-4a9b-4c18-866b-a2c013f75fc7\"", 
-                    "SummaryItem"]}], 
-                    RowBox[{
-                    TagBox["\"Protocol: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"ZMQ_PAIR\"", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {
-                    ShowStringCharacters -> False, NumberMarks -> False, 
-                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-                    GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}], True -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SquareMinusIconMedium"]], 
-                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
-                    None, Evaluator -> Automatic, Method -> "Preemptive"], 
-                    Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 3.5 CurrentValue["FontCapHeight"]/
-                    AbsoluteCurrentValue[Magnification]}]], 
-                    GraphicsBox[
-                    GeometricTransformationBox[{{{
-                    FilledCurveBox[{{
-                    
-                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
-                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
-                    36.558, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
-                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
-                    59.053, 8.569}}]}}]}, {{
-                    FilledCurveBox[{{
-                    
-                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
-                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
-                    55.487, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
-                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
-                    52.562, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
-                    51.099000000000004`, 21.188000000000002`}, {49.636, 
-                    21.188000000000002`}, {49.636, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
-                    48.172000000000004`, 21.188000000000002`}, {46.709, 
-                    21.188000000000002`}, {46.709, 8.569}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
-                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
-                    43.783, 8.569}}]}}]}}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
-                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
-                    4.911}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
-                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
-                    31.675}}]}}]}, {
-                    FilledCurveBox[{{
-                    
-                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
-                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
-                    43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
-                    ImageSize -> {Automatic, 
-                    Dynamic[
-                    3.5 CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification]]}, PlotRange -> {{20, 80}, {0, 70}}, 
-                    BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
-                    
-                    GridBox[{{
-                    RowBox[{
-                    TagBox[
-                    "\"DestinationIPAddress: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    RowBox[{"IPAddress", "[", "\"127.0.0.1\"", "]"}], 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"DestinationPort: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"63781\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"SourceIPAddress: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    
-                    RowBox[{"IPAddress", "[", "\"::500:5bde:ff17:6166\"", 
-                    "]"}], "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"SourcePort: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"0\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"Protocol: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"ZMQ_PAIR\"", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {
-                    ShowStringCharacters -> False, NumberMarks -> False, 
-                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-                    GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}]}, 
-                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
-                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
-                   SocketObject["ZMQ-3ef55c1d-4a9b-4c18-866b-a2c013f75fc7"], 
-                   Selectable -> False, Editable -> False, SelectWithContents -> 
-                   True], "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"EvaluationCount: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  DynamicBox[
-                   ToBoxes[
-                    If[
-                    TrueQ[
-                    ExternalEvaluate`Private`getSessionOpts[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91", "Exists"]], 
-                    ExternalSessionObject[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91"][
-                    "EvaluationCount"], None], StandardForm], 
-                   TrackedSymbols :> {ExternalEvaluate`Private`$Links}], 
-                  "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"ProcessMemory: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  DynamicBox[
-                   ToBoxes[
-                    If[
-                    TrueQ[
-                    ExternalEvaluate`Private`getSessionOpts[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91", "Exists"]], 
-                    Refresh[
-                    ExternalSessionObject[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91"]["ProcessMemory"], 
-                    UpdateInterval -> 5], 
-                    Missing["NotAvailable"]], StandardForm], 
-                   TrackedSymbols :> {ExternalEvaluate`Private`$Links}], 
-                  "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"ProcessThreads: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  DynamicBox[
-                   ToBoxes[
-                    If[
-                    TrueQ[
-                    ExternalEvaluate`Private`getSessionOpts[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91", "Exists"]], 
-                    Refresh[
-                    ExternalSessionObject[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91"]["ProcessThreads"],
-                     UpdateInterval -> 5], 
-                    Missing["NotAvailable"]], StandardForm], 
-                   TrackedSymbols :> {ExternalEvaluate`Private`$Links}], 
-                  "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"SessionTime: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  DynamicBox[
-                   ToBoxes[
-                    If[
-                    TrueQ[
-                    ExternalEvaluate`Private`getSessionOpts[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91", "Exists"]], 
-                    Refresh[
-                    ExternalSessionObject[
-                    "9d054758-6742-4dc1-bdf0-92cfab26dc91"]["SessionTime"], 
-                    UpdateInterval -> 1], 
-                    Missing["NotAvailable"]], StandardForm], 
-                   TrackedSymbols :> {ExternalEvaluate`Private`$Links}], 
-                  "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-          GridBoxAlignment -> {"Rows" -> {{Top}}}, AutoDelete -> False, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}]}, 
-       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
-     "SummaryPanel"],
-    DynamicModuleValues:>{}], "]"}],
-  ExternalSessionObject["9d054758-6742-4dc1-bdf0-92cfab26dc91"],
-  Editable->False,
-  SelectWithContents->True,
-  Selectable->False]], "Output",
- CellChangeTimes->{
-  3.834825666132516*^9, 3.846040782326826*^9, 3.8460410050460367`*^9, 
-   3.8460417800745296`*^9, 3.84604188615975*^9, {3.84604207782257*^9, 
-   3.846042090548864*^9}, 3.846042311852193*^9, 3.846158308474115*^9, 
-   3.8461667215366983`*^9, 3.846407988043374*^9, 3.84640814915168*^9, 
-   3.846408238546768*^9},
- CellLabel->"Out[5]=",ExpressionUUID->"e620fb46-ca28-4cc2-9a58-49a749a12856"]
-}, Open  ]],
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"TestExpr", "[", 
-   RowBox[{"expr_", ",", " ", 
-    RowBox[{"verbose_", ":", "False"}], ",", " ", 
-    RowBox[{"tol_", ":", "1*^-8"}]}], "]"}], ":=", 
-  RowBox[{"Module", "[", 
-   RowBox[{
-    RowBox[{"{", 
-     RowBox[{"exprPy", ",", "resM", ",", "resP", ",", " ", "valid"}], "}"}], 
-    ",", "\[IndentingNewLine]", 
-    RowBox[{"(*", " ", 
-     RowBox[{
-     "Function", " ", "that", " ", "compares", " ", "the", " ", "Mathematica",
-       " ", "result", " ", "to", " ", "the", " ", "python", " ", "result"}], 
-     " ", "*)"}], "\[IndentingNewLine]", 
-    RowBox[{
-     RowBox[{"exprPy", "=", 
-      RowBox[{"ToPython", "[", 
-       RowBox[{"expr", ",", 
-        RowBox[{"Copy", "\[Rule]", "False"}]}], "]"}]}], ";", 
-     "\[IndentingNewLine]", 
-     RowBox[{"(*", " ", 
-      RowBox[{
-      "evaluate", " ", "the", " ", "expressions", " ", "in", " ", 
-       "Mathematica", " ", "and", " ", "in", " ", "python"}], " ", "*)"}], 
-     "\[IndentingNewLine]", 
-     RowBox[{"resM", "=", 
-      RowBox[{"Normal", "[", 
-       RowBox[{"expr", "/.", "vals"}], "]"}]}], ";", "\[IndentingNewLine]", 
-     "\[IndentingNewLine]", 
-     RowBox[{"If", "[", 
-      RowBox[{
-       RowBox[{"ArrayQ", "[", "resM", "]"}], ",", "\[IndentingNewLine]", 
-       RowBox[{"resP", "=", 
-        RowBox[{"N", "@", 
-         RowBox[{"ExternalEvaluate", "[", 
-          RowBox[{"session", ",", 
-           RowBox[{"exprPy", "<>", "\"\<.tolist()\>\""}]}], "]"}]}]}], 
-       "\[IndentingNewLine]", ",", 
-       RowBox[{"(*", "else", "*)"}], "\[IndentingNewLine]", 
-       RowBox[{"resP", "=", 
-        RowBox[{"N", "@", 
-         RowBox[{"ExternalEvaluate", "[", 
-          RowBox[{"session", ",", "exprPy"}], "]"}]}]}]}], 
-      "\[IndentingNewLine]", "]"}], ";", "\[IndentingNewLine]", 
-     RowBox[{"valid", "=", 
-      RowBox[{
-       RowBox[{"Norm", "[", 
-        RowBox[{"resM", "-", "resP"}], "]"}], "<", 
-       RowBox[{"tol", "+", 
-        RowBox[{"tol", "*", 
-         RowBox[{"Mean", "[", 
-          RowBox[{"Norm", "/@", 
-           RowBox[{"{", 
-            RowBox[{"resM", ",", "resP"}], "}"}]}], "]"}]}]}]}]}], ";", 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"If", "[", 
-      RowBox[{"verbose", ",", 
-       RowBox[{"Print", "@", 
-        RowBox[{"StringForm", "[", 
-         RowBox[{"\"\<`` =?= ``\>\"", ",", " ", "resM", ",", " ", "resP"}], 
-         "]"}]}]}], "]"}], ";", "\[IndentingNewLine]", 
-     RowBox[{"If", "[", 
-      RowBox[{
-       RowBox[{"valid", "=!=", "True"}], ",", "\[IndentingNewLine]", 
-       RowBox[{"Print", "@", 
-        RowBox[{"StringForm", "[", 
-         RowBox[{
-         "\"\<Error:\\nMathematica: ``\\nPythonForm: ``\\n`` != `` (diff: ``)\
-\>\"", ",", "\[IndentingNewLine]", 
-          RowBox[{"InputForm", "@", "expr"}], ",", "exprPy", ",", "resM", ",",
-           "resP", ",", 
-          RowBox[{"Norm", "[", 
-           RowBox[{"resM", "-", "resP"}], "]"}]}], "]"}]}]}], 
-      "\[IndentingNewLine]", "]"}], ";"}]}], "\[IndentingNewLine]", 
-   "]"}]}]], "Input",
- CellChangeTimes->{{3.8170417020811777`*^9, 3.81704172657474*^9}, {
-  3.81704179280335*^9, 3.817041840489778*^9}, {3.817041927575897*^9, 
-  3.817042036063344*^9}, {3.8170421879989634`*^9, 3.817042226019485*^9}, {
-  3.817042299961542*^9, 3.817042425907525*^9}, {3.8171187981847067`*^9, 
-  3.817118837881874*^9}, {3.817118869098439*^9, 3.817118901147331*^9}, {
-  3.817118980087762*^9, 3.81711925677897*^9}, {3.81711928731602*^9, 
-  3.817119290162525*^9}, {3.8171196009707813`*^9, 3.8171196235745583`*^9}, {
-  3.817133292637014*^9, 3.817133292955245*^9}, {3.8172200224753237`*^9, 
-  3.817220038170822*^9}, {3.8172201143851852`*^9, 3.817220171218865*^9}, {
-  3.8172202219502983`*^9, 3.817220222379529*^9}, {3.817220443941942*^9, 
-  3.8172204825096703`*^9}, {3.817220514090167*^9, 3.817220515003347*^9}, {
-  3.8348256851524878`*^9, 3.8348256887404423`*^9}, {3.846042112354926*^9, 
-  3.846042137622614*^9}},
- CellLabel->"In[10]:=",ExpressionUUID->"1daf2eb3-6166-48ed-992f-1473b56947a1"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test cases", "Section",
- CellChangeTimes->{{3.846042058634193*^9, 
-  3.8460420644426203`*^9}},ExpressionUUID->"a27a99f9-bd12-46d4-8624-\
-85cc4f3e3bb5"],
-
-Cell[CellGroupData[{
-
-Cell["Test numeric examples", "Subsection",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041924803459*^9}},ExpressionUUID->"5185dd86-dec4-4c26-8e48-\
-124321882ccc"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", "2", "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041922919067*^9}},
- CellLabel->"In[11]:=",ExpressionUUID->"d2ab5645-70dd-4a4c-a916-861a7f41c40f"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"1", "/", "3"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041908793754*^9}},
- CellLabel->"In[12]:=",ExpressionUUID->"bf998445-7f53-4e06-aa2b-bbedde1dd042"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"1.", "/", "3"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041911460279*^9}},
- CellLabel->"In[13]:=",ExpressionUUID->"ad674aef-74e7-4220-8935-283e9c43e016"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", "2.31", "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041912381846*^9}},
- CellLabel->"In[14]:=",ExpressionUUID->"891d4fba-9677-40a3-aa36-ac911d861410"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"2.31", "+", 
-   RowBox[{"5.3", "I"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.8460419129741993`*^9}},
- CellLabel->"In[15]:=",ExpressionUUID->"d7af6c11-af2c-467a-a27e-4d20c06250f9"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", "1*^30", "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041913542753*^9}},
- CellLabel->"In[16]:=",ExpressionUUID->"9da2859f-5de4-41ed-834e-b6411e93e3c8"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", "1*^-30", "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041914105044*^9}},
- CellLabel->"In[17]:=",ExpressionUUID->"6967dc5d-a3ee-456d-8e2b-c49ae6fd06df"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"N", "[", 
-   RowBox[{"Pi", ",", "40"}], "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020708510957*^9}, {3.817041939215971*^9, 
-  3.817041941599523*^9}, {3.8170421343013906`*^9, 3.817042142368922*^9}, {
-  3.8170422708990498`*^9, 3.8170422957666273`*^9}, {3.817120307551271*^9, 
-  3.817120316935302*^9}, {3.817273522417403*^9, 3.817273542125928*^9}, {
-  3.817273580569841*^9, 3.817273583701936*^9}, {3.846041902853119*^9, 
-  3.846041914651318*^9}},
- CellLabel->"In[18]:=",ExpressionUUID->"b724c4b6-a2eb-4f9d-816c-3b5afb62e3f1"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test simple expressions", "Subsection",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, {3.846041929532474*^9, 
-   3.846041932973956*^9}},ExpressionUUID->"740923fd-dd9e-45ca-b781-\
-36fcddb044a7"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"a", "+", "b"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, 3.846041973392763*^9},
- CellLabel->"In[19]:=",ExpressionUUID->"622a3868-cc93-4e9f-9244-dd90a3b0e230"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"a", "+", "b", "+", "d"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041973899994*^9}},
- CellLabel->"In[20]:=",ExpressionUUID->"d01a1f82-0634-497a-bd28-045fa1359270"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"a", "*", "b"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041974404408*^9}},
- CellLabel->"In[21]:=",ExpressionUUID->"d0960264-a1eb-4839-825b-0c85d421789c"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"a", "*", "b", "*", "c"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041974950733*^9}},
- CellLabel->"In[22]:=",ExpressionUUID->"43e88e09-b2cb-4b40-9ef3-257eb977fb9c"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"a", "/", "b"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041975415821*^9}},
- CellLabel->"In[23]:=",ExpressionUUID->"b7ce3257-a3a1-47e8-b3d8-3b4360a0a4a2"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{
-   RowBox[{"(", 
-    RowBox[{"a", "+", "b"}], ")"}], "/", 
-   RowBox[{"(", 
-    RowBox[{"d", "+", "e", "+", "g"}], ")"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041976071169*^9}},
- CellLabel->"In[24]:=",ExpressionUUID->"8430173d-a223-44f9-8854-a777595d6f28"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{
-   RowBox[{"(", 
-    RowBox[{"a", "+", "b"}], ")"}], "^", 
-   RowBox[{"(", 
-    RowBox[{"d", "+", "e", "+", "g"}], ")"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041976569558*^9}},
- CellLabel->"In[25]:=",ExpressionUUID->"6dac367c-012b-4f05-910e-5e1cdb6b9d36"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"Exp", "[", 
-   RowBox[{"a", "+", "b"}], "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041977947075*^9}},
- CellLabel->"In[26]:=",ExpressionUUID->"e89b6c2c-4333-4c40-b1b7-71690b6227c0"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{
-   RowBox[{"Sin", "[", 
-    RowBox[{"(", 
-     RowBox[{"a", "+", "b"}], ")"}], "]"}], "/", 
-   RowBox[{"Cos", "[", 
-    RowBox[{"d", "+", "e"}], "]"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041978438273*^9}},
- CellLabel->"In[27]:=",ExpressionUUID->"e8909287-f2aa-46b1-82c2-11d3ae21304d"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{
-   RowBox[{"Sin", "[", 
-    RowBox[{"(", 
-     RowBox[{"a", "+", "b"}], ")"}], "]"}], "/", 
-   RowBox[{"Tanh", "[", 
-    RowBox[{"d", "+", "e"}], "]"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041978892454*^9}},
- CellLabel->"In[28]:=",ExpressionUUID->"67fd3b61-19e7-4444-9c7b-8d4becc7480c"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"\[Pi]", " ", 
-   RowBox[{"Cosh", "[", "a", "]"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.8460419793917923`*^9}},
- CellLabel->"In[29]:=",ExpressionUUID->"fdef6874-99c9-4558-8fca-639ab5cd2100"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"1", "/", 
-   RowBox[{"Sqrt", "[", "a", "]"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-   3.8170418609071417`*^9, 3.817041872218865*^9}, 3.817042250551552*^9, {
-   3.817120284841795*^9, 3.817120284977632*^9}, {3.817273573444448*^9, 
-   3.8172735792254133`*^9}, {3.8243812261167088`*^9, 3.824381227200451*^9}, {
-   3.824385042461767*^9, 3.82438504484193*^9}, {3.8460407883889914`*^9, 
-   3.846040796525504*^9}, 3.846041929532474*^9, {3.846041973392763*^9, 
-   3.846041979873971*^9}},
- CellLabel->"In[30]:=",ExpressionUUID->"dd120ca1-848e-423b-8132-8a4ad1af66b7"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test more complex expression", "Subsection",
- CellChangeTimes->{{3.846158166621696*^9, 
-  3.846158172465621*^9}},ExpressionUUID->"f8397244-1ddc-4683-9ba2-\
-1631f6f2ff53"],
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"xs", "=", 
-   RowBox[{"x", "/.", 
-    RowBox[{"Solve", "[", 
-     RowBox[{
-      RowBox[{
-       RowBox[{
-        RowBox[{"a", "*", 
-         RowBox[{"x", "^", "2"}]}], "-", 
-        RowBox[{"b", "*", "x"}], "+", "c"}], "\[Equal]", "0"}], ",", "x"}], 
-     "]"}]}]}], ";"}]], "Input",
- CellChangeTimes->{{3.846158181269034*^9, 3.846158184218039*^9}, {
-  3.8461582922280684`*^9, 3.846158299353643*^9}, {3.846158415782278*^9, 
-  3.846158482201703*^9}, {3.8461591530743628`*^9, 3.846159182503839*^9}, {
-  3.84616668901619*^9, 3.84616671474564*^9}},
- CellLabel->"In[31]:=",ExpressionUUID->"4a484416-8716-4c9a-a177-e23d82b841bf"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"xs", "[", 
-   RowBox[{"[", "1", "]"}], "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.846158181269034*^9, 3.846158184218039*^9}, {
-  3.8461582922280684`*^9, 3.846158299353643*^9}, {3.846158415782278*^9, 
-  3.846158482201703*^9}, {3.8461591530743628`*^9, 3.846159188526732*^9}},
- CellLabel->"In[32]:=",ExpressionUUID->"4124d2cf-9243-403b-88b8-8fc04ac56def"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"xs", "[", 
-   RowBox[{"[", "2", "]"}], "]"}], "]"}]], "Input",
- CellChangeTimes->{3.8461591911438313`*^9},
- CellLabel->"In[33]:=",ExpressionUUID->"05090169-8f98-4d80-a8c4-a624f7083a03"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "@", 
-  RowBox[{"Assuming", "[", 
-   RowBox[{
-    RowBox[{
-     RowBox[{"a", ">", "0"}], "&&", 
-     RowBox[{"c", ">", "0"}]}], ",", 
-    RowBox[{"Simplify", "@", 
-     RowBox[{"Norm", "@", 
-      RowBox[{"{", 
-       RowBox[{
-        RowBox[{"{", 
-         RowBox[{
-          RowBox[{"Sin", "[", "a", "]"}], ",", 
-          RowBox[{"Sqrt", "[", "c", "]"}]}], "}"}], ",", 
-        RowBox[{"{", 
-         RowBox[{"2", ",", 
-          RowBox[{"a", "^", "2"}]}], "}"}]}], "}"}]}]}]}], "]"}]}]], "Input",
- CellChangeTimes->{{3.846408000340914*^9, 3.846408017120659*^9}, {
-  3.84640816301118*^9, 3.846408179006751*^9}},
- CellLabel->"In[34]:=",ExpressionUUID->"47d0e7b8-7fc1-41ab-a340-d7245957e301"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test constants", "Subsection",
- CellChangeTimes->{{3.817219734532898*^9, 3.817219757613577*^9}, {
-  3.81727358772644*^9, 3.8172735887082853`*^9}, {3.846041981098611*^9, 
-  3.8460419985237017`*^9}},ExpressionUUID->"8b3d5e80-8e20-438b-87ee-\
-ceea90da1c2e"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", "Pi", "]"}]], "Input",
- CellChangeTimes->{{3.817219734532898*^9, 3.817219757613577*^9}, {
-  3.81727358772644*^9, 3.8172735887082853`*^9}, {3.846041981098611*^9, 
-  3.846041982203734*^9}},
- CellLabel->"In[35]:=",ExpressionUUID->"37d2d871-953e-4c23-bc44-f83a3b622304"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", "E", "]"}]], "Input",
- CellChangeTimes->{{3.817219734532898*^9, 3.817219757613577*^9}, {
-  3.81727358772644*^9, 3.8172735887082853`*^9}, {3.846041981098611*^9, 
-  3.846041982203734*^9}},
- CellLabel->"In[36]:=",ExpressionUUID->"8f765bef-c3b4-4a72-889e-faed0af5e750"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"N", "@", 
-   RowBox[{"Sqrt", "[", "2", "]"}]}], "]"}]], "Input",
- CellChangeTimes->{{3.817219734532898*^9, 3.817219757613577*^9}, {
-  3.81727358772644*^9, 3.8172735887082853`*^9}, {3.846041981098611*^9, 
-  3.846041983003277*^9}},
- CellLabel->"In[37]:=",ExpressionUUID->"d58c4ae4-2ee3-4f60-8649-e005867fbd14"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"N", "@", "Pi"}], "]"}]], "Input",
- CellChangeTimes->{{3.817219734532898*^9, 3.817219757613577*^9}, {
-  3.81727358772644*^9, 3.8172735887082853`*^9}, {3.846041981098611*^9, 
-  3.846041983504922*^9}},
- CellLabel->"In[38]:=",ExpressionUUID->"beed9989-7b46-45f6-b92e-d9534e983cae"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test array handling", "Subsection",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020703952483*^9}, {3.817042042716785*^9, 
-  3.817042043976235*^9}, {3.81711939281493*^9, 3.817119394171856*^9}, {
-  3.817133214478402*^9, 3.817133216574778*^9}, {3.817220529995721*^9, 
-  3.8172205307949047`*^9}, {3.817273590716207*^9, 3.817273591432549*^9}, {
-  3.846041987064098*^9, 
-  3.846042008138753*^9}},ExpressionUUID->"292185a9-2fb5-4cee-ba04-\
-979e10b4d536"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"{", 
-   RowBox[{"a", ",", "b", ",", "c"}], "}"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020703952483*^9}, {3.817042042716785*^9, 
-  3.817042043976235*^9}, {3.81711939281493*^9, 3.817119394171856*^9}, {
-  3.817133214478402*^9, 3.817133216574778*^9}, {3.817220529995721*^9, 
-  3.8172205307949047`*^9}, {3.817273590716207*^9, 3.817273591432549*^9}, {
-  3.846041987064098*^9, 3.8460419875670156`*^9}},
- CellLabel->"In[39]:=",ExpressionUUID->"9325edd7-eacf-45d9-a0aa-6cb7fc2b9707"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"{", 
-   RowBox[{"{", 
-    RowBox[{"1", ",", "2", ",", "3"}], "}"}], "}"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020703952483*^9}, {3.817042042716785*^9, 
-  3.817042043976235*^9}, {3.81711939281493*^9, 3.817119394171856*^9}, {
-  3.817133214478402*^9, 3.817133216574778*^9}, {3.817220529995721*^9, 
-  3.8172205307949047`*^9}, {3.817273590716207*^9, 3.817273591432549*^9}, {
-  3.846041987064098*^9, 3.846041988161628*^9}},
- CellLabel->"In[40]:=",ExpressionUUID->"8c4b586c-c3d0-42ee-a1e6-2e373492ac18"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"Cos", "[", 
-   RowBox[{"{", 
-    RowBox[{"1", ",", "2", ",", "3"}], "}"}], "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020703952483*^9}, {3.817042042716785*^9, 
-  3.817042043976235*^9}, {3.81711939281493*^9, 3.817119394171856*^9}, {
-  3.817133214478402*^9, 3.817133216574778*^9}, {3.817220529995721*^9, 
-  3.8172205307949047`*^9}, {3.817273590716207*^9, 3.817273591432549*^9}, {
-  3.846041987064098*^9, 3.846041988725069*^9}},
- CellLabel->"In[41]:=",ExpressionUUID->"55454dae-6e1e-4815-94e6-523a2247c161"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"NumericArray", "[", 
-   RowBox[{
-    RowBox[{"{", 
-     RowBox[{
-      RowBox[{"{", 
-       RowBox[{"1", ",", "2"}], "}"}], ",", 
-      RowBox[{"{", 
-       RowBox[{"3", ",", "4"}], "}"}]}], "}"}], ",", "\"\<Integer32\>\""}], 
-   "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.817007935108295*^9, 3.817007961051466*^9}, {
-  3.817020691587697*^9, 3.817020703952483*^9}, {3.817042042716785*^9, 
-  3.817042043976235*^9}, {3.81711939281493*^9, 3.817119394171856*^9}, {
-  3.817133214478402*^9, 3.817133216574778*^9}, {3.817220529995721*^9, 
-  3.8172205307949047`*^9}, {3.817273590716207*^9, 3.817273591432549*^9}, {
-  3.846041987064098*^9, 3.846041988725069*^9}},
- CellLabel->"In[42]:=",ExpressionUUID->"80f5a18a-2e1c-43d0-9b42-8e79c2facab6"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test special functions of one argument", "Subsection",
- CellChangeTimes->{{3.817119378001226*^9, 3.817119478821705*^9}, {
-  3.817119841126937*^9, 3.8171199085150433`*^9}, {3.817120294809811*^9, 
-  3.8171202949819508`*^9}, {3.817273244838635*^9, 3.817273261133836*^9}, {
-  3.817273561872357*^9, 3.817273563524414*^9}, {3.8460419904284897`*^9, 
-  3.846042015638241*^9}},ExpressionUUID->"9004b91b-2ef8-48dc-bf1f-\
-39d9648a9831"],
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"Map", "[", 
-   RowBox[{
-    RowBox[{
-     RowBox[{"TestExpr", "[", 
-      RowBox[{"#", "[", 
-       RowBox[{"a", "-", "c"}], "]"}], "]"}], "&"}], ",", 
-    RowBox[{"{", 
-     RowBox[{
-     "Log10", ",", "Sqrt", ",", "Exp", ",", "Sin", ",", "Cos", ",", "Tan", 
-      ",", "Csc", ",", "Sec", ",", "Cot", ",", "Sinh", ",", "Cosh", ",", 
-      "Tanh", ",", "Csch", ",", "Sech", ",", "Coth", ",", " ", "Gamma"}], 
-     "}"}]}], "]"}], ";"}]], "Input",
- CellChangeTimes->{{3.817119378001226*^9, 3.817119478821705*^9}, {
-   3.817119841126937*^9, 3.8171199085150433`*^9}, {3.817120294809811*^9, 
-   3.8171202949819508`*^9}, {3.817273244838635*^9, 3.817273261133836*^9}, {
-   3.817273561872357*^9, 3.817273563524414*^9}, 3.8460419904284897`*^9},
- CellLabel->"In[43]:=",ExpressionUUID->"0c207f89-6be0-4cb7-b228-331ba7e2e930"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test special functions of two arguments", "Subsection",
- CellChangeTimes->{{3.817219195028184*^9, 3.817219220967013*^9}, {
-   3.817219323326161*^9, 3.8172193325693407`*^9}, {3.817273233785985*^9, 
-   3.817273259608906*^9}, 3.846041991510054*^9, {3.846042023129198*^9, 
-   3.846042032414493*^9}},ExpressionUUID->"07df250e-87b1-4228-9a21-\
-d011319228fc"],
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"Map", "[", 
-   RowBox[{
-    RowBox[{
-     RowBox[{"TestExpr", "[", 
-      RowBox[{"#", "[", 
-       RowBox[{"a", ",", "b"}], "]"}], "]"}], "&"}], ",", 
-    RowBox[{"{", 
-     RowBox[{
-     "Gamma", ",", "BesselI", ",", "BesselJ", ",", "BesselK", ",", 
-      "BesselY"}], "}"}]}], "]"}], ";"}]], "Input",
- CellChangeTimes->{{3.817219195028184*^9, 3.817219220967013*^9}, {
-   3.817219323326161*^9, 3.8172193325693407`*^9}, {3.817273233785985*^9, 
-   3.817273259608906*^9}, 3.846041991510054*^9},
- CellLabel->"In[44]:=",ExpressionUUID->"9662f5ee-5f1f-4b30-aa68-fe818f5045fd"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell["Test special functions for more complicated cases", "Subsection",
- CellChangeTimes->{{3.8172735000772457`*^9, 3.817273508216394*^9}, {
-  3.846041992808167*^9, 3.846041993470435*^9}, {3.846042027978241*^9, 
-  3.846042030735072*^9}},ExpressionUUID->"4e89ff29-6ed5-4222-b155-\
-669840286e53"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"Arg", "[", 
-   RowBox[{"a", "+", 
-    RowBox[{"b", " ", "I"}]}], "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.8172735000772457`*^9, 3.817273508216394*^9}, {
-  3.846041992808167*^9, 3.846041993470435*^9}},
- CellLabel->"In[45]:=",ExpressionUUID->"66c391ad-09e8-4146-b5f4-2fbcc12aa3d5"],
-
-Cell[BoxData[
- RowBox[{"TestExpr", "[", 
-  RowBox[{"SphericalHarmonicY", "[", 
-   RowBox[{"b", ",", "a", ",", "c", ",", "d"}], "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.8172735000772457`*^9, 3.817273508216394*^9}, 
-   3.846041992808167*^9},
- CellLabel->"In[46]:=",ExpressionUUID->"01377ee4-a30f-447b-8174-2568e047951d"]
-}, Open  ]]
-}, Open  ]]
-},
-WindowSize->{808, 701},
-WindowMargins->{{172, Automatic}, {Automatic, 144}},
-FrontEndVersion->"12.1 for Mac OS X x86 (64-bit) (March 13, 2020)",
-StyleDefinitions->"Default.nb",
-ExpressionUUID->"58567f7e-6c45-40f5-80ec-2593b646d55a"
+  ,
+  StyleDefinitions -> "Default.nb"
+  ,
+  ExpressionUUID -> "58567f7e-6c45-40f5-80ec-2593b646d55a"
 ]
+
 (* End of Notebook Content *)
 
 (* Internal cache information *)
+
 (*CellTagsOutline
 CellTagsIndex->{}
 *)
+
 (*CellTagsIndex
 CellTagsIndex->{}
 *)
+
 (*NotebookFileOutline
 Notebook[{
 Cell[558, 20, 884, 20, 73, "Input",ExpressionUUID->"ee6242fe-5738-42d7-927d-12c3be9f45f8"],
@@ -1546,4 +1134,3 @@ Cell[67773, 1441, 323, 6, 30, "Input",ExpressionUUID->"01377ee4-a30f-447b-8174-2
 }
 ]
 *)
-


### PR DESCRIPTION
@david-zwicker  This PR leaves code unchanged but has changed the formatting of two .nb, one .wl and one .md file using the WL linter for VS code. Feel free to ignore nb and readme changes, but .wl seems more readable.
Essentially, the changes in code formatting are as per the wolfram language linter for VS code. I'd set up auto-linting on save and the formatting was done automatically when I commited the .wl file. 

Sorry, it took a while to reply (I had to remember what I'd done!).

(btw, I don't think I can request a review to PR if I am not in the organisation/have write access to your repo)

