### PR TITLE
Add support for functions with multiple arguments

### DIFF
--- a/ToPython.wl
+++ b/ToPython.wl
@@ -140,7 +140,7 @@ ToPython[expression_, OptionsPattern[]] :=
              -> "gamma", "\[Delta]" -> "delta", "\[Epsilon]" -> "epsilon", "\[CurlyEpsilon]"
              -> "curlyepsilon", "\[Zeta]" -> "zeta", "\[Eta]" -> "eta", "\[Theta]"
              -> "theta", "\[Iota]" -> "iota", "\[Kappa]" -> "kappa", "\[Lambda]" 
-            -> "lambda", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
+            -> "lamb", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
              -> "omicron", "\[Pi]" -> "pi", "\[Rho]" -> "rho", "\[FinalSigma]" ->
              "finalsigma", "\[Sigma]" -> "sigma", "\[Tau]" -> "tau", "\[Upsilon]"
              -> "upsilon", "\[CurlyPhi]" -> "curlyphi", "\[Chi]" -> "chi", "\[Phi]"

--- a/ToPython.wl
+++ b/ToPython.wl
@@ -134,12 +134,13 @@ ToPython[expression_, OptionsPattern[]] :=
         (* Constants *)
         PythonForm[\[Pi]] = np <> "pi";
         PythonForm[E] = np <> "e";
+        PythonForm[a_,b__] := PythonForm[a]<>","<>PythonForm[b];
         (* Greek characters *)
         greekrule = {"\[Alpha]" -> "alpha", "\[Beta]" -> "beta", "\[Gamma]"
              -> "gamma", "\[Delta]" -> "delta", "\[Epsilon]" -> "epsilon", "\[CurlyEpsilon]"
              -> "curlyepsilon", "\[Zeta]" -> "zeta", "\[Eta]" -> "eta", "\[Theta]"
              -> "theta", "\[Iota]" -> "iota", "\[Kappa]" -> "kappa", "\[Lambda]" 
-            -> "lamb", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
+            -> "lambda", "\[Mu]" -> "mu", "\[Nu]" -> "nu", "\[Xi]" -> "xi", "\[Omicron]"
              -> "omicron", "\[Pi]" -> "pi", "\[Rho]" -> "rho", "\[FinalSigma]" ->
              "finalsigma", "\[Sigma]" -> "sigma", "\[Tau]" -> "tau", "\[Upsilon]"
              -> "upsilon", "\[CurlyPhi]" -> "curlyphi", "\[Chi]" -> "chi", "\[Phi]"


### PR DESCRIPTION
Previously some binary operators and functions with more variables lead to problems. For example,
```mma
Import["https://raw.githubusercontent.com/zwicker-group/MathematicaToPython/master/ToPython.wl"]
ToPython[a . b + c]
```
invokes error
<img width="502" alt="image" src="https://github.com/zwicker-group/MathematicaToPython/assets/47470964/a28d84c8-7d9e-424c-b992-7ab34966273a">
and output
```mma
"c + np.dot(<>Private`PythonForm$51284[a, b]<>)"
```
due to that `PythonForm` only supports one argument.  This can be solved by simply call the function PythonForm recursively.